### PR TITLE
Serialize string fields

### DIFF
--- a/Packages/com.cnlohr.cilbox/CilboxProxy.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxProxy.cs
@@ -89,7 +89,7 @@ namespace Cilbox
 					if( !bHandled )
 					{
 						StackType st;
-						if( StackElement.TypeToStackType.TryGetValue( fv.GetType().ToString(), out st ) && st < StackType.Object )
+						if( StackElement.TypeToStackType.TryGetValue( fv.GetType().ToString(), out st ) && st < StackType.Object || fv is string )
 							instanceFields[f.Name] = new Serializee( fv.ToString() );
 						else if( fv.GetType() == typeof(String) )
 							instanceFields[f.Name] = new Serializee( fv.ToString() );								


### PR DESCRIPTION
If the Cilboxable has a public string field or SerializeField string field, write it into the CilboxProxy serialized object data.

Previously, this caused Breakwarn Boolean to String cast errors, or the string was interpreted as False.

Don't know what I'm doing