### PR TITLE
transfer interpreted exceptions through method calls

### DIFF
--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -334,6 +334,7 @@ spiperf.Begin();
 					case 0x73: //newobj
 					case 0x6F: //callvirt
 					{
+						int currentInstruction = pc - 1;
 						uint bc = (b == 0x29) ? stackBuffer[sp--].u : BytecodeAsU32( ref pc );
 						object iko = null; // Returned value.
 						CilMetadataTokenInfo dt = box.metadatas[bc];
@@ -425,7 +426,14 @@ spiperf.Begin();
 										}
 									}
 									stackBuffer[nextParameterStart].LoadObject( newObj );
-									targetMethod.InterpretInner( stackBufferIn.Slice( nextStackHead ), stackBufferIn.Slice( nextParameterStart, numParams + staticOffset ) );
+									try
+									{
+										targetMethod.InterpretInner(stackBufferIn.Slice(nextStackHead), stackBufferIn.Slice(nextParameterStart, numParams + staticOffset));
+									}
+									catch (CilboxUnhandledInterpretedException e)
+									{
+										interpretedThrow(currentInstruction, e.Throwee);
+									}
 									stackBuffer[++sp].LoadObject( newObj );
 								}
 								else
@@ -433,10 +441,17 @@ spiperf.Begin();
 									if( !targetMethod.isStatic )
 										stackBuffer[nextParameterStart] = stackBuffer[sp--];
 
-									if( !isVoid && !ctorAsCall )
-										stackBuffer[++sp] = targetMethod.InterpretInner( stackBufferIn.Slice( nextStackHead ), stackBufferIn.Slice( nextParameterStart, numParams + staticOffset ) );
-									else
-										targetMethod.InterpretInner( stackBufferIn.Slice( nextStackHead ), stackBufferIn.Slice( nextParameterStart, numParams + staticOffset ) );
+									try
+									{
+										if (!isVoid && !ctorAsCall)
+											stackBuffer[++sp] = targetMethod.InterpretInner(stackBufferIn.Slice(nextStackHead), stackBufferIn.Slice(nextParameterStart, numParams + staticOffset));
+										else
+											targetMethod.InterpretInner(stackBufferIn.Slice(nextStackHead), stackBufferIn.Slice(nextParameterStart, numParams + staticOffset));
+									}
+									catch (CilboxUnhandledInterpretedException e)
+									{
+										interpretedThrow(currentInstruction, e.Throwee);
+									}
 								}
 
 								if( isJmp )
@@ -1518,6 +1533,11 @@ spiperf.End();
 				}
 				while( cont );
 			}
+			catch (CilboxUnhandledInterpretedException)
+			{
+				// don't break program flow for interpreted exceptions; we want to pass flow back to the outer call.
+				throw;
+			}
 			catch( Exception e )
 			{
 				string fullError = $"Breakwarn: {e.ToString()} Class: {parentClass.className}, Function: {methodName}, Bytecode: {pc}";
@@ -1547,8 +1567,7 @@ spiperf.End();
 				exceptionRegister = new StackElement() { type = StackType.Object, o = thrownObj };
 				if (!hasExceptionClauses)
 				{
-					// todo: figure out how to re-throw to outer interpreter.
-					throw new CilboxInterpreterRuntimeException("Exception thrown with no handlers: " + thrownObj.ToString(), parentClass.className, methodName, currentInstruction);
+					throw new CilboxUnhandledInterpretedException("Exception thrown with no handlers: " + thrownObj.ToString(), thrownObj, parentClass.className, methodName, currentInstruction);
 				}
 
 				CilboxExceptionHandlingClause found = null;
@@ -1583,15 +1602,15 @@ spiperf.End();
 							continue;
 						}
 					}
-						else if (c.CatchTypeName != null)
+					else if (c.CatchTypeName != null)
+					{
+						// Cilboxable type match
+						// todo: it isn't actually possible to throw a Cilboxable type (yet?)
+						if (!IsInternalObjectInstanceOf(thrownObj, c.CatchTypeName))
 						{
-							// Cilboxable type match
-							// todo: it isn't actually possible to throw a Cilboxable type (yet?)
-							if (!IsInternalObjectInstanceOf(thrownObj, c.CatchTypeName))
-							{
-								continue;
-							}
+							continue;
 						}
+					}
 					else
 					{
 						continue;
@@ -1603,8 +1622,7 @@ spiperf.End();
 
 				if (found == null)
 				{
-					// how do I handle this?
-					throw new CilboxInterpreterRuntimeException("No handlers matched exception: " + thrownObj.ToString(), parentClass.className, methodName, currentInstruction);
+					throw new CilboxUnhandledInterpretedException("No handlers matched exception: " + thrownObj.ToString(), thrownObj, parentClass.className, methodName, currentInstruction);
 				}
 
 				leaveRegionEnqueueFinallys(currentInstruction, found.HandlerOffset, true);

--- a/Packages/com.cnlohr.cilbox/CilboxUtil.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxUtil.cs
@@ -420,6 +420,17 @@ namespace Cilbox
 		}
 	}
 
+	public class CilboxUnhandledInterpretedException : CilboxInterpreterRuntimeException
+	{
+		public readonly object Throwee;
+
+		public CilboxUnhandledInterpretedException(string msg, object throwee, string className, string methodName, int pc) :
+			base(msg, className, methodName, pc)
+		{
+			Throwee = throwee;
+		}
+	}
+
 	///////////////////////////////////////////////////////////////////////////
 	//  SERIALIZATION / DESERIALIZATION  //////////////////////////////////////
 	///////////////////////////////////////////////////////////////////////////

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -251,7 +251,8 @@ namespace TestCilbox
 			Cilbox.Cilbox cb = cbobj.AddComponent<CilboxTester>();
 			cb.exportDebuggingData = true;
 
-			cb.timeoutLengthUs = 50000; // 50ms
+			// let the CI take its time running Start()
+			cb.timeoutLengthUs = 200000; // 200ms
 			Cilbox.CilboxScenePostprocessor.OnPostprocessScene();
 			Application.CallBeforeRender();
 
@@ -283,17 +284,23 @@ namespace TestCilbox
 				// Make sure CI can fail.
 				//Validator.Validate( "Test Fail Check", "This will fail" );
 			}
-			catch( CilboxInterpreterTimeoutException e )
+			catch( Exception e )
 			{
 				Validator.Validate( e.ToString(), "Should be no error." );
 			}
 
 			try
 			{
+				// Ensure 50ms timeout for the Update test.
+				cb.timeoutLengthUs = 50000; // 50ms
 				// In case assembly is still being generated.
 				proxy.GetType().GetMethod("Update",BindingFlags.Instance|BindingFlags.NonPublic,Type.EmptyTypes).Invoke( proxy, new object[0] );
-			} catch( Exception e )
+			} catch( TargetInvocationException e )
 			{
+				if (e.InnerException is not CilboxInterpreterTimeoutException)
+				{
+					throw;
+				}
 				Debug.Log( e.ToString().Length.ToString() );
 				Validator.Set( "Overtime Exception", "Thrown" );
 			}
@@ -466,8 +473,13 @@ namespace TestCilbox
 			Validator.Validate("myBehaviour3Arr 1", "456");
 			Validator.Validate("myBehaviour3Arr 1 changed", "789");
 
+			Validator.Validate("ThrowFromOtherBehaviour1", "caught");
+			Validator.Validate("ThrowFromOtherBehaviour2", "caught");
+			Validator.Validate("ThrowFromOtherBehaviour2Finally", "finally");
+			Validator.Validate("ThrowFromOtherConstructor", "caught");
+
 			return -1 * Validator.NumValidationErrors();
-			}
 		}
+	}
 }
 

--- a/TestCilbox/TestCilboxable.cs
+++ b/TestCilbox/TestCilboxable.cs
@@ -360,8 +360,41 @@ namespace TestCilbox
 			Validator.Set("myBehaviour3Arr 1", myBehaviour3Arr[1].number.ToString());
 			myBehaviour3Arr[1].number = 789;
 			Validator.Set("myBehaviour3Arr 1 changed", myBehaviour3Arr[1].number.ToString());
-				
+
+			try
+			{
+				Validator.Set("ThrowFromOtherBehaviour1", "try");
+				behaviour2.ThrowExceptionTest();
 			}
+			catch (Exception)
+			{
+				Validator.Set("ThrowFromOtherBehaviour1", "caught");
+			}
+
+			try
+			{
+				Validator.Set("ThrowFromOtherBehaviour2", "try");
+				behaviour2.ThrowNativeExceptionTest();
+			}
+			catch (IndexOutOfRangeException)
+			{
+				Validator.Set("ThrowFromOtherBehaviour2", "caught");
+			}
+			finally
+			{
+				Validator.Set("ThrowFromOtherBehaviour2Finally", "finally");
+			}
+
+			try
+			{
+				Validator.Set("ThrowFromOtherConstructor", "try");
+				TestCilboxExceptConstructor exceptConstructor = new TestCilboxExceptConstructor();
+			}
+			catch (Exception)
+			{
+				Validator.Set("ThrowFromOtherConstructor", "caught");
+			}
+		}
 
 		public void Update()
 		{
@@ -524,6 +557,17 @@ namespace TestCilbox
 			Validator.Set( "Method Called On Peer", "OK" );
 			Validator.Set( "Public Field Change In Editor", pubsettee.ToString() ); // Should not be 35254
 		}
+
+		public void ThrowExceptionTest()
+		{
+			throw new Exception("Test Exception from Behaviour2");
+		}
+
+		public int ThrowNativeExceptionTest()
+		{
+			int[] emptyArr = new int[0];
+			return emptyArr[0];
+		}
 	}
 
 	[Cilboxable]
@@ -531,6 +575,12 @@ namespace TestCilbox
 	{
 		public TestCilboxBehaviour3(int value) {this.number = value;}
 		public int number = 123;
+	}
+
+	[Cilboxable]
+	public class TestCilboxExceptConstructor
+	{
+		public TestCilboxExceptConstructor() { throw new Exception("Constructor Exception"); }
 	}
 }
 


### PR DESCRIPTION
This PR enables exceptions to be transferred and caught between method calls.

To facilitate this, I have introduced a new special kind of exception `CilboxUnhandledInterpretedException`, which will be thrown if no handlers are found that match a thrown exception. It carries the thrown `object`.
At calls to `InterpretInner`, this exception is caught and then the carried object is "thrown" through `interpretedThrow()`.
