### PR TITLE
catch unhandled exception and strip throwee & disable box

### DIFF
--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -197,9 +197,20 @@ namespace Cilbox
 			try
 			{
 				ret = InterpretInner( stackBuffer, parameters ).AsObject();
-			} catch( Exception e )
+			}
+			catch( Exception e )
 			{
 				parentClass.box.InterpreterExit();
+
+				if (e is CilboxUnhandledInterpretedException uhe)
+				{
+					// strip the throwee just in case, and re-throw a normal runtime exception
+					string exceptionTypeName = uhe.Throwee?.GetType().FullName ?? "null";
+					string reason = $"Exception of type {exceptionTypeName} was unhandled in interpreted code";
+					parentClass.box.DisableWithReason(reason); // CilboxUnhandledInterpretedException bypasses the box disable
+					throw new CilboxInterpreterRuntimeException(reason, uhe.ClassName, uhe.MethodName, uhe.PC);
+				}
+
 				Debug.Log( e.ToString() );
 				throw;
 			}
@@ -1541,10 +1552,7 @@ spiperf.End();
 			catch( Exception e )
 			{
 				string fullError = $"Breakwarn: {e.ToString()} Class: {parentClass.className}, Function: {methodName}, Bytecode: {pc}";
-				Debug.LogError( fullError );
-				box.disabledReason = fullError;
-				box.disabled = true;
-				//box.InterpreterExit();
+				box.DisableWithReason(fullError);
 
 				if (e is CilboxInterpreterRuntimeException)
 				{
@@ -2327,6 +2335,14 @@ spiperf.End();
 		void Update()
 		{
 			usSpentLastFrame = Interlocked.Exchange( ref interpreterAccountingCumulitiveTicks, 0 ) / interpreterTicksInUs;
+		}
+
+		internal void DisableWithReason(string reason)
+		{
+			Debug.LogError( reason );
+			this.disabledReason = reason;
+			this.disabled = true;
+			//this.InterpreterExit();
 		}
 	}
 


### PR DESCRIPTION
Here is the output when I throw and don't handle an exception:
```
Postprocessing scene. Cilbox scripts to do: 2
🔵 TestCilboxBehaviour.Start()
Exception of type System.Exception was unhandled in interpreted code
❌ System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> Cilbox.CilboxInterpreterRuntimeException: Exception of type System.Exception was unhandled in interpreted code @ (TestCilbox.TestCilboxBehaviour.Start, PC: 3839)
   at Cilbox.CilboxMethod.Interpret(CilboxProxy ths, Object[] parametersIn) in E:\Projects\Unity\Other\cilbox\Packages\com.cnlohr.cilbox\Cilbox.cs:line 211
   at Cilbox.Cilbox.InterpretIID(CilboxClass cls, CilboxProxy ths, ImportFunctionID iid, Object[] parameters) in E:\Projects\Unity\Other\cilbox\Packages\com.cnlohr.cilbox\Cilbox.cs:line 2266
   at Cilbox.CilboxProxy.Start() in E:\Projects\Unity\Other\cilbox\Packages\com.cnlohr.cilbox\CilboxProxy.cs:line 473
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
   --- End of inner exception stack trace ---
   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
   at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters)
   at TestCilbox.Program.Main(String[] args) in E:\Projects\Unity\Other\cilbox\TestCilbox\TestCilbox.cs:line 365 is unset (Expected Should be no error.)
❌ Overtime Exception is unset (Expected Thrown)
❌ Overtime is unset (Expected timed out)
❌ Update is unset (Expected called)
✅ Execution after timeout = disabled 
✅ Manual Recover After Timeout = recovered 
✅ FixedUpdate = called 
✅ Dispose = disposed 
✅ TryFinally = finally 
✅ TryFinally2 = finally 
✅ Exited Dispose Tester = yes 
✅ TryCatch = caught 
✅ TryFinally count = 1 
✅ TryFinally2 count = 1 
✅ TryFinally3 = finally 
✅ TryFinally3 count = 1 
✅ NullReferenceException = caught1 
✅ NullRefUnreachable = didn't reach 
✅ TryFinallyNestedTest1 = finally 
✅ TryFinallyNestedTest2 = bottom 
✅ TryFinallyNestedTest1 count = 1 
✅ DivideByZeroException = caught 
✅ JoinFloatArrayResized = 1.5, 2.5, 3.5, 4.5 
✅ DictionaryKeys = key1, key2 
✅ ComplexGenericType = String, Int32, Boolean, Char 
✅ TestVec.x = 12 
✅ TestVec.y = 8 
✅ New myInt = 42 
✅ New testVec.y = 42 
✅ FieldAccessNullRef = caught 
✅ ReadInt_1 = 14 
✅ ReadFloat_1 = 8 
✅ WriteInt_1 = 42 
✅ WriteFloat_1 = 42 
✅ NegativeIndexAccess = caught 
✅ PositiveIndexAccess = caught 
✅ StfldNullRef = caught 
✅ LdfldaNullRef = caught 
✅ ReadByte_1 = 200 
✅ WriteByte_1 = 42 
✅ New myByte = 42 
✅ ReadShort_1 = 1234 
✅ WriteShort_1 = 99 
✅ New myShort = 99 
✅ ReadLong_1 = 9876543210 
✅ WriteLong_1 = 42 
✅ New myLong = 42 
✅ ReadDouble_1 = 3.14 
✅ WriteDouble_1 = 2.718 
✅ New myDouble = 2.718 
✅ ReadString_1 = hello 
✅ WriteString_1 = world 
✅ New myString = world 
✅ ReadCilboxable = 12345 
✅ WriteCilboxable = 12345 
✅ RefCilboxable Same = True 
✅ NativeRefMethodCall = 11 
✅ Vector3CheckThis = OK 
✅ MyEnum.Value1 = Value1 
✅ MyEnum.Value2 = Value2 
✅ MyEnum.Value3 = Value3 
✅ (int)MyEnum.Value1 = 0 
✅ (int)MyEnum.Value2 = 1 
✅ (int)MyEnum.Value3 = 30 
✅ MyEnum Field = Value2 
✅ (int)MyEnum Field = 1 
✅ MyEnum Field == Value1 = False 
✅ MyEnum Field == Value2 = True 
✅ MyEnum Field == Value3 = False 
✅ (int)MyEnum Field == Value1 = False 
✅ (int)MyEnum Field == Value2 = True 
✅ (int)MyEnum Field == Value3 = False 
✅ TestEnum.FirstValue = FirstValue 
✅ TestEnum.SecondValue = SecondValue 
✅ TestEnum.ThirdValue = ThirdValue 
✅ (int)TestEnum.FirstValue = 0 
✅ (int)TestEnum.SecondValue = 1 
✅ (int)TestEnum.ThirdValue = 30 
✅ TestEnum Field = SecondValue 
✅ (int)TestEnum Field = 1 
✅ TestEnum Field == FirstValue = False 
✅ TestEnum Field == SecondValue = True 
✅ TestEnum Field == ThirdValue = False 
✅ (int)TestEnum Field == FirstValue = False 
✅ (int)TestEnum Field == SecondValue = True 
✅ (int)TestEnum Field == ThirdValue = False 
✅ TestEnumNativeEqualsFirstValue = False 
✅ TestEnumNativeEqualsSecondValue = True 
✅ TestEnumNativeEqualsThirdValue = False 
✅ MyEnumMethod count = 2 
✅ MyEnumMethod_1 = Value1 
✅ MyEnumMethod_2 = Value2 
✅ TestEnumMethod count = 2 
✅ TestEnumMethod_1 = FirstValue 
✅ TestEnumMethod_2 = SecondValue 
✅ MyEnum Array 0 = Value1 
✅ MyEnum Array int value 0 = 0 
✅ MyEnum Array 1 = Value2 
✅ MyEnum Array int value 1 = 1 
✅ MyEnum Array 2 = Value3 
✅ MyEnum Array int value 2 = 30 
✅ TestEnum Array 0 = FirstValue 
✅ TestEnum Array int value 0 = 0 
✅ TestEnum Array 1 = SecondValue 
✅ TestEnum Array int value 1 = 1 
✅ TestEnum Array 2 = ThirdValue 
✅ TestEnum Array int value 2 = 30 
✅ Boxed MyEnum = Value2 
✅ Boxed TestEnum = SecondValue 
✅ NativeStaticFloat = 5 
✅ NativeStaticFloat x2 = 10 
✅ ReadFloat_2 = 10 
✅ WriteFloat_2 = 99 
✅ NativeStaticFloat ref written = 99 
✅ ReadInt_2 = 1114 
✅ NativeOutVec3 = (12, 8, 0) 
✅ CilOutVec3 = (1, 2, 3) 
✅ NativeOutInt = 42 
✅ CilOutInt = 22 
✅ NativeOutVec3AlreadyInit = (12, 8, 0) 
✅ myBehaviour3Arr Length = 2 
✅ myBehaviour3Arr 0 = 123 
✅ myBehaviour3Arr 1 = 456 
✅ myBehaviour3Arr 1 changed = 789 
✅ ThrowFromOtherBehaviour1 = caught 
✅ ThrowFromOtherBehaviour2 = caught 
✅ ThrowFromOtherBehaviour2Finally = finally 
✅ ThrowFromOtherConstructor = caught 

Process finished with exit code -4.
```