### PR TITLE
add MaxTimeoutLengthUs to Cilbox

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -1453,7 +1453,7 @@ MonoBehaviour:
   verboseLogging: 0
   disabledReason: 
   disabled: 0
-  timeoutLengthUs: 500000
+  desiredTimeoutLengthUs: 400000
   interpreterAccountingDepth: 0
   interpreterAccountingDropDead: 0
   interpreterAccountingCumulitiveTicks: 0

--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -1,6 +1,7 @@
 //#define PER_INSTRUCTION_PROFILING
 
 using UnityEngine;
+using UnityEngine.Serialization;
 using System.Collections.Generic;
 using System;
 using System.Collections.Specialized;
@@ -1944,7 +1945,15 @@ spiperf.End();
 		public String disabledReason = "";
 		public bool disabled = false;
 
-		public long timeoutLengthUs = 500000; // 500ms Can be changed by specific Cilbox application.
+		[SerializeField][FormerlySerializedAs("timeoutLengthUs")] private long desiredTimeoutLengthUs = 500000; // 500ms Can be changed by specific Cilbox instance.
+		public long timeoutLengthUs
+		{
+			get => desiredTimeoutLengthUs;
+			set => desiredTimeoutLengthUs = Math.Min(value, MaxTimeoutLengthUs);
+		}
+
+		public virtual long MaxTimeoutLengthUs => 1000000; // 1 second. Can be overridden by specific Cilbox application.
+
 		[HideInInspector] public uint interpreterAccountingDepth = 0;
 		[HideInInspector] public long interpreterAccountingDropDead = 0;
 		[HideInInspector] public long interpreterAccountingCumulitiveTicks = 0;
@@ -1978,6 +1987,7 @@ spiperf.End();
 			if( initialized ) return;
 			initialized = true;
 			//Debug.Log( "Cilbox Initialize Metadata:" + assemblyData.Length );
+			timeoutLengthUs = desiredTimeoutLengthUs; // make sure min is applied once.
 
 			Dictionary< String, Serializee > assemblyRoot = new Serializee( Convert.FromBase64String( assemblyData ), Serializee.ElementType.Map ).AsMap();
 			Dictionary< String, Serializee > classData = assemblyRoot["classes"].AsMap();

--- a/Packages/com.cnlohr.cilbox/CilboxAvatar.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxAvatar.cs
@@ -11,6 +11,8 @@ namespace Cilbox
 	[CilboxTarget]
 	public class CilboxAvatar : Cilbox
 	{
+		public override long MaxTimeoutLengthUs => 5000; // 5ms. Avatas need to be restrictive.
+
 		static HashSet<String> whiteListType = new HashSet<String>(){
 			"Cilbox.CilboxPublicUtils",
 			"System.Array",
@@ -70,11 +72,6 @@ namespace Cilbox
 			"UnityEngine.Vector3.y",
 			"UnityEngine.Vector3.z",
 		};
-
-		public CilboxAvatar()
-		{
-			timeoutLengthUs = 5000; // Limit avatars to 5ms.
-		}
 
 		static public HashSet<String> GetWhiteListTypes() { return whiteListType; }
 

--- a/Packages/com.cnlohr.cilbox/CilboxScene.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxScene.cs
@@ -11,6 +11,8 @@ namespace Cilbox
 	[CilboxTarget]
 	public class CilboxScene : Cilbox
 	{
+		public override long MaxTimeoutLengthUs => 10000000; // 10 seconds. Let scenes go crazy.
+
 		static HashSet<String> whiteListType = new HashSet<String>(){
 			"Cilbox.CilboxPublicUtils",
 			"System.Array",

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -16,6 +16,8 @@ namespace TestCilbox
 	[CilboxTarget]
 	public class CilboxTester : Cilbox.Cilbox
 	{
+		public override long MaxTimeoutLengthUs => 2000000; // 2 seconds.
+
 		static HashSet<String> whiteListType = new HashSet<String>(){
 			"Cilbox.CilboxPublicUtils",
 			"TestCilbox.DisposeTester",
@@ -413,6 +415,10 @@ namespace TestCilbox
 
 			cb.disabled = false;
 			proxy.GetType().GetMethod("FixedUpdate",BindingFlags.Instance|BindingFlags.NonPublic,Type.EmptyTypes).Invoke( proxy, new object[0] );
+
+			cb.timeoutLengthUs = 3000000; // should be over max
+			Validator.Set("Real timeoutLengthUs", cb.timeoutLengthUs.ToString() );
+			Validator.Validate("Real timeoutLengthUs", cb.MaxTimeoutLengthUs.ToString() );
 
 			Validator.Validate( "Manual Recover After Timeout", "recovered" );
 			Validator.Validate( "FixedUpdate", "called" );

--- a/TestCilbox/UnityEngine.cs
+++ b/TestCilbox/UnityEngine.cs
@@ -308,4 +308,18 @@ namespace UnityEngine
 	}
 
 	// We don't _really_ do serialization.
+
+	[AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
+	public class SerializeFieldAttribute : Attribute { }
+}
+
+namespace UnityEngine.Serialization
+{
+	[AttributeUsage(AttributeTargets.Field, AllowMultiple = true, Inherited = false)]
+	public class FormerlySerializedAsAttribute : Attribute
+	{
+		private string m_oldName;
+		public FormerlySerializedAsAttribute(string oldName) => this.m_oldName = oldName;
+		public string oldName => this.m_oldName;
+	}
 }


### PR DESCRIPTION
I want to make sure Cilboxes of a certain type can not exceed their max timeout in a way that is easy for the implementing application to manage.

I added a property `MaxTimeoutLengthUs` which can be overridden by any descendant of `Cilbox` and is used as a cap when setting `timeoutLengthUs` which I converted to a property. I preserved the original serialized field with an attribute for any components already added to scenes. Using a property for the max allows applications to be pretty flexible such as using a configurable value for the max instead of a constant.

I just put some values for all of the defaults, so let me know if you'd like me to change any of them, or approach this a different way.
