### PR TITLE
Fix Value Type array assignment, because Value-type array's can not be converted to Objects.

### DIFF
--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -1374,22 +1374,39 @@ spiperf.Begin();
 							interpretedThrow(pc - 1, new NullReferenceException());
 							break;
 						}
-						object [] array = (object[])arrSE.AsObject();
+						Array array = (Array)arrSE.AsObject();
 						if (index < 0 || index >= array.Length)
 						{
 							interpretedThrow(pc - 1, new IndexOutOfRangeException());
 							break;
 						}
 						CilMetadataTokenInfo elemMeta = box.metadatas[otyp];
+						object value;
 						if( elemMeta.nativeTypeIsCilboxProxy || elemMeta.nativeType == null )
 						{
 							// This actually gets the value in valSE, and converts it to the int/float/native handle, etc. based on "this" box.
-							array[index] = valSE.AsObject( box );
+							value = valSE.AsObject( box );
 						}
 						else
 						{
-							array[index] = Convert.ChangeType( valSE.AsObject(), elemMeta.nativeType );  // This shouldn't be type changing.s
+							value = valSE.AsObject();
 						}
+
+						Type targetElementType = array.GetType().GetElementType();
+						if( targetElementType != null && targetElementType != typeof(object) && !targetElementType.IsInstanceOfType( value ) )
+						{
+							if( targetElementType.IsEnum )
+							{
+								value = Enum.ToObject( targetElementType, value );
+							}
+							else
+							{
+								if( value.GetType().IsEnum )
+									value = Convert.ChangeType( value, Enum.GetUnderlyingType( value.GetType() ) );
+								value = Convert.ChangeType( value, targetElementType );
+							}
+						}
+						array.SetValue( value, index );
 						break;
 					}
 					case 0xA5: // unbox.any

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -46,6 +46,7 @@ namespace TestCilbox
 			"System.IntPtr",
 			"System.MathF",
 			"System.NullReferenceException",
+			"System.Numerics.Vector2",
 			"System.Object",
 			"System.Single",
 			"System.String",
@@ -667,6 +668,10 @@ namespace TestCilbox
 			Validator.Validate("Double Array With Data 0", "4.5");
 			Validator.Validate("Double Array With Data 1", "6.25");
 			Validator.Validate("Double Array With Data 2", "8.75");
+
+			Validator.Validate("Static Readonly Vector2 Array Length", "2");
+			Validator.Validate("Static Readonly Vector2 Array 0", "<1, 2>");
+			Validator.Validate("Static Readonly Vector2 Array 1", "<3.5, 4.5>");
 
 			Validator.Validate("Object Array Assigned Length", "3");
 			Validator.Validate("Object Array Assigned 0", "alpha");

--- a/TestCilbox/TestCilboxable.cs
+++ b/TestCilbox/TestCilboxable.cs
@@ -18,6 +18,11 @@ namespace TestCilbox
 		static private int iprivatestatic = 557;
 		static public int ipublicstatic = 558;
 		static public int recursive_test_counter = 0;
+		private static readonly System.Numerics.Vector2[] staticReadonlyVector2Array = new System.Numerics.Vector2[]
+		{
+			new System.Numerics.Vector2(1.0f, 2.0f),
+			new System.Numerics.Vector2(3.5f, 4.5f),
+		};
 		public TestCilboxBehaviour2 behaviour2;
 		public int[] intArr = new int[] { 1, 2, 3 };
 		public TestCilboxBehaviour3[] myBehaviour3Arr;
@@ -473,6 +478,12 @@ namespace TestCilbox
 			Validator.Set("Double Array With Data 0", doubleWithData[0].ToString() );
 			Validator.Set("Double Array With Data 1", doubleWithData[1].ToString() );
 			Validator.Set("Double Array With Data 2", doubleWithData[2].ToString() );
+
+			Validator.Set("Static Readonly Vector2 Array Length", staticReadonlyVector2Array.Length.ToString() );
+			for (int j = 0; j < staticReadonlyVector2Array.Length; j++)
+			{
+				Validator.Set("Static Readonly Vector2 Array " + j, staticReadonlyVector2Array[j].ToString() );
+			}
 
 			object[] objectAssigned = new object[3];
 			objectAssigned[0] = "alpha";


### PR DESCRIPTION
At the current moment Vector2 is a IEquatable<Vector2>, Iformattable so its not an object.
This makes sure the Type is the correct type before being put onto the stack.