### PR TITLE
CilboxProxy: reduce allocations and quadratic work during runtime load

### DIFF
--- a/Packages/com.cnlohr.cilbox/CilboxProxy.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxProxy.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 #if UNITY_EDITOR
 using Unity.Profiling;
 #endif
+using System.Text;
 
 namespace Cilbox
 {
@@ -210,12 +211,19 @@ namespace Cilbox
 				new ProfilerMarker( "Initialize " + className ).Auto();
 #endif
 
-				GameObject obj = gameObject;
-				initialLoadPath = "/" + obj.name;
-				while (obj.transform.parent != null)
+				// Build initialLoadPath in O(n) — the old "/" + name + path concat was O(depth^2) per proxy.
 				{
-					obj = obj.transform.parent.gameObject;
-					initialLoadPath = "/" + obj.name + initialLoadPath;
+					Transform cur = transform;
+					List<string> parts = new List<string>(8);
+					while (cur != null)
+					{
+						parts.Add(cur.gameObject.name);
+						cur = cur.parent;
+					}
+					StringBuilder sb = new StringBuilder(64);
+					for (int i = parts.Count - 1; i >= 0; i--)
+						sb.Append('/').Append(parts[i]);
+					initialLoadPath = sb.ToString();
 				}
 
 				if( string.IsNullOrEmpty( className ) )
@@ -264,31 +272,32 @@ namespace Cilbox
 				}
 
 				// Populate fields[]
-				fields = new StackElement[cls.instanceFieldNames.Length];
+				int fieldCount = cls.instanceFieldNames.Length;
+				fields = new StackElement[fieldCount];
 
 				Serializee [] d = new Serializee( Convert.FromBase64String( serializedObjectData ), Serializee.ElementType.Map ).AsArray();
 
-				Serializee [] matchingSerializeeInstanceField = new Serializee[cls.instanceFieldNames.Length];
+				Serializee [] matchingSerializeeInstanceField = new Serializee[fieldCount];
+				Dictionary< String, Serializee > [] matchingDicts = new Dictionary< String, Serializee >[fieldCount];
 				foreach( Serializee s in d )
 				{
 					// Go over the root objects, to see which ones slot in and how.
+					// Cache the parsed dict so the load pass below doesn't reparse.
 					Dictionary< String, Serializee > dict = s.AsMap();
-					Serializee val;
-					Serializee miid;
-					if( dict.TryGetValue( "t", out val ) && dict.TryGetValue( "miid", out miid ) )
+					if( dict.ContainsKey( "t" ) && dict.TryGetValue( "miid", out Serializee miid ) )
 					{
-						UInt32 nMIID = UInt32.MaxValue;
-						if( UInt32.TryParse( miid.AsString(), out nMIID ) &&
-							nMIID < matchingSerializeeInstanceField.Length )
+						if( UInt32.TryParse( miid.AsString(), out UInt32 nMIID ) &&
+							nMIID < fieldCount )
 						{
 							matchingSerializeeInstanceField[nMIID] = s;
+							matchingDicts[nMIID] = dict;
 						}
 					}
 				}
 
 				// Preinitialize every field to its CLR default value so that non-serialized fields
 				// (especially UnityEngine.Object references) are not left as implicit StackType.Boolean.
-				for( int i = 0; i < cls.instanceFieldNames.Length; i++ )
+				for( int i = 0; i < fieldCount; i++ )
 				{
 					Type fieldType = cls.instanceFieldTypes[i];
 					// Maybe need to GetComponentTypeOverride here as well?  Maybe not, since that should only be for actual UnityEngine.Objects, which should be null at this point if they are contraband.
@@ -332,14 +341,14 @@ namespace Cilbox
 				box.InterpretIID( cls, this, ImportFunctionID.dotCtor, null );
 
 				// load serialized fields.
-				for( int i = 0; i < cls.instanceFieldNames.Length; i++ )
+				for( int i = 0; i < fieldCount; i++ )
 				{
 					Serializee s = matchingSerializeeInstanceField[i];
 
 					if( s == null ) { /* Debug.Log( $"Skipping {i} {cls.instanceFieldNames[i]}" ); */ continue; }
 
 					object o;
-					bool bIsObject = LoadObjectFromSerializee( s, out o, cls.instanceFieldNames[i], cls.instanceFieldTypes[i], true );
+					bool bIsObject = LoadObjectFromSerializee( s, out o, cls.instanceFieldNames[i], cls.instanceFieldTypes[i], true, matchingDicts[i] );
 					if( bIsObject )
 						fields[i].LoadObject( o );
 					else
@@ -347,6 +356,10 @@ namespace Cilbox
 				}
 
 				proxyWasSetup = true;
+				// Release the serialized blob and original object list — they're only needed during load
+				// and the proxyWasSetup guard above prevents re-entry. Keeps ~a kB per proxy off the GC heap.
+				serializedObjectData = null;
+				fieldsObjects = null;
 				if (verboseLogging)
 					Debug.Log( $"RuntimeProxyLoad complete for class {className}" );
 			}
@@ -358,9 +371,10 @@ namespace Cilbox
 
 
 		// Returns: true if is object, otherwise is primitive.
-		private bool LoadObjectFromSerializee( Serializee s, out object oOut, String rootFieldName, Type inType, bool root )
+		// `dict` may be supplied by callers that already parsed the Serializee to avoid a redundant AsMap allocation.
+		private bool LoadObjectFromSerializee( Serializee s, out object oOut, String rootFieldName, Type inType, bool root, Dictionary< String, Serializee > dict = null )
 		{
-			Dictionary< String, Serializee > dict = s.AsMap();
+			if( dict == null ) dict = s.AsMap();
 
 			Serializee setype;
 			if( dict.TryGetValue( "t", out setype ) )
@@ -444,11 +458,13 @@ namespace Cilbox
 
 						Array arr = Array.CreateInstance( t, aLen );
 
-						int j;
-						for( j = 0; j < aLen; j++ )
+						// Hoist AsArray out of the loop — it previously re-parsed seAD and allocated
+						// a fresh Serializee[] of size aLen on every iteration (O(aLen^2) GC).
+						Serializee [] adArr = seAD.AsArray();
+						for( int j = 0; j < aLen; j++ )
 						{
 							object o;
-							LoadObjectFromSerializee( seAD.AsArray()[j], out o, rootFieldName, t, false );
+							LoadObjectFromSerializee( adArr[j], out o, rootFieldName, t, false );
 							arr.SetValue( o, j );
 						}
 


### PR DESCRIPTION
## Summary

While profiling scenes in [Basis](https://github.com/BasisVR/Basis) that instantiate many `[Cilboxable]` objects, `CilboxProxy.RuntimeProxyLoad` showed up as a hotspot for GC pressure and (for deep hierarchies) time. None of this is a correctness issue — just small waste that stacks linearly with proxy count. This PR addresses the pieces I found; semantics are unchanged.

## Changes

All in `Packages/com.cnlohr.cilbox/CilboxProxy.cs`:

1. **`initialLoadPath` build is now O(n).** The previous loop did `initialLoadPath = "/" + obj.name + initialLoadPath` each iteration, which allocates a new string of length proportional to the running path — O(depth²) allocations and copies per proxy. Replaced with a `List<string>` walk up the transform chain and a single `StringBuilder` pass.

2. **Cache the parsed root-map `Dictionary` across the two passes.** The first pass over the serialized field map calls `s.AsMap()` on every root `Serializee` to inspect `"t"` / `"miid"`. The second pass in `LoadObjectFromSerializee` then called `s.AsMap()` again on the same `Serializee` — reparsing the exact same bytes. Now we stash the parsed dict in `matchingDicts[nMIID]` alongside the `Serializee` and pass it through to `LoadObjectFromSerializee` as an optional arg, which falls back to the old `AsMap()` call when no dict is supplied (so every other caller keeps working unchanged).

3. **Hoist `seAD.AsArray()` out of the array-element load loop.** Previously this was called inside `for( j = 0; j < aLen; j++ )` as `seAD.AsArray()[j]`, and `AsArray()` reparses the underlying buffer and allocates a fresh `Serializee[]` of size `aLen` each call — O(aLen²) garbage for a single field. Now called once before the loop.

4. **Release `serializedObjectData` and `fieldsObjects` after load.** Both are documented as only being held during saving/loading. Once `proxyWasSetup = true` is set, the guard at the top of `RuntimeProxyLoad` prevents re-entry, so there's no path that would re-read them. Holding them pinned ~a kB per proxy on the GC heap for the object's lifetime.

5. Minor: `int fieldCount = cls.instanceFieldNames.Length;` hoisted, and one `TryGetValue("t", out val)` that ignored its `out` collapsed to `ContainsKey("t")`. Inline `out` variable declarations where it read better.

## What this doesn't change

- Same fields populated in the same order with the same values.
- Same exception paths (contraband array check, missing object slot warnings, etc.).
- Same side effects on `fieldsObjects` during the contraband scan.
- `LoadObjectFromSerializee`'s new `dict` parameter has a default of `null`, so no existing call sites need to change.

## Testing

Tested under Basis with scenes containing several hundred cilboxed proxies, including some with deep transform hierarchies. Runtime load-phase allocations measurably drop, and deep-hierarchy `initialLoadPath` construction no longer scales quadratically. No behavior or whitelist changes observed.

## Test plan

- [ ] Existing build CI passes (`.github/workflows/build.yml`)
- [ ] Spot-check a scene with a deep transform chain: `initialLoadPath` on the proxy matches the pre-change string (leading `/`, root-to-leaf order)
- [ ] Spot-check a class with an array-of-struct field: values round-trip identically after load

🤖 Generated with [Claude Code](https://claude.com/claude-code)