### PR TITLE
Cilboxproxy load perf

### DIFF
--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -1223,30 +1223,6 @@ spiperf.Begin();
 						}
 						break;
 					}
-					case 0x81: // stobj
-					{
-						uint typeToken = BytecodeAsU32( ref pc );
-						CilMetadataTokenInfo stobjMeta = box.metadatas[typeToken];
-						StackElement value = stackBuffer[sp--];
-						StackElement addr = stackBuffer[sp--];
-						object obj = ( stobjMeta.nativeType != null && value.type < StackType.Object ) ?
-							value.CoerceToObject( stobjMeta.nativeType ) :
-							value.AsObject( box );
-
-						if( addr.type == StackType.Address )
-						{
-							addr.DereferenceLoadAddress( obj );
-						}
-						else if( addr.type == StackType.NativeHandle )
-						{
-							addr.DereferenceLoadNativeHandle( box, obj );
-						}
-						else
-						{
-							throw new CilboxInterpreterRuntimeException("Invalid stack type for stobj instruction", parentClass.className, methodName, pc);
-						}
-						break;
-					}
 					case 0x8C: // box (This pulls off a type)
 					{
 						uint otyp = BytecodeAsU32( ref pc );
@@ -1398,39 +1374,22 @@ spiperf.Begin();
 							interpretedThrow(pc - 1, new NullReferenceException());
 							break;
 						}
-						Array array = (Array)arrSE.AsObject();
+						object [] array = (object[])arrSE.AsObject();
 						if (index < 0 || index >= array.Length)
 						{
 							interpretedThrow(pc - 1, new IndexOutOfRangeException());
 							break;
 						}
 						CilMetadataTokenInfo elemMeta = box.metadatas[otyp];
-						object value;
 						if( elemMeta.nativeTypeIsCilboxProxy || elemMeta.nativeType == null )
 						{
 							// This actually gets the value in valSE, and converts it to the int/float/native handle, etc. based on "this" box.
-							value = valSE.AsObject( box );
+							array[index] = valSE.AsObject( box );
 						}
 						else
 						{
-							value = valSE.AsObject();
+							array[index] = Convert.ChangeType( valSE.AsObject(), elemMeta.nativeType );  // This shouldn't be type changing.s
 						}
-
-						Type targetElementType = array.GetType().GetElementType();
-						if( targetElementType != null && targetElementType != typeof(object) && !targetElementType.IsInstanceOfType( value ) )
-						{
-							if( targetElementType.IsEnum )
-							{
-								value = Enum.ToObject( targetElementType, value );
-							}
-							else
-							{
-								if( value.GetType().IsEnum )
-									value = Convert.ChangeType( value, Enum.GetUnderlyingType( value.GetType() ) );
-								value = Convert.ChangeType( value, targetElementType );
-							}
-						}
-						array.SetValue( value, index );
 						break;
 					}
 					case 0xA5: // unbox.any
@@ -2088,7 +2047,7 @@ spiperf.End();
 		abstract public bool CheckMethodAllowed( out MethodInfo mi, Type declaringType, String name, Serializee [] parametersIn, Serializee [] genericArgumentsIn, String fullSignature );
 		abstract public bool CheckTypeAllowed( String sType );
 		abstract public bool CheckFieldAllowed( String sType, String sFieldName );
-		abstract public bool GetComponentTypeOverride( String sType, out Type t );
+		abstract public bool GetTypeOverride( String sType, out Type t );
 
 		public delegate void CilboxDisabledEvent( Cilbox box, string reason );
 

--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -1223,6 +1223,30 @@ spiperf.Begin();
 						}
 						break;
 					}
+					case 0x81: // stobj
+					{
+						uint typeToken = BytecodeAsU32( ref pc );
+						CilMetadataTokenInfo stobjMeta = box.metadatas[typeToken];
+						StackElement value = stackBuffer[sp--];
+						StackElement addr = stackBuffer[sp--];
+						object obj = ( stobjMeta.nativeType != null && value.type < StackType.Object ) ?
+							value.CoerceToObject( stobjMeta.nativeType ) :
+							value.AsObject( box );
+
+						if( addr.type == StackType.Address )
+						{
+							addr.DereferenceLoadAddress( obj );
+						}
+						else if( addr.type == StackType.NativeHandle )
+						{
+							addr.DereferenceLoadNativeHandle( box, obj );
+						}
+						else
+						{
+							throw new CilboxInterpreterRuntimeException("Invalid stack type for stobj instruction", parentClass.className, methodName, pc);
+						}
+						break;
+					}
 					case 0x8C: // box (This pulls off a type)
 					{
 						uint otyp = BytecodeAsU32( ref pc );
@@ -1374,22 +1398,40 @@ spiperf.Begin();
 							interpretedThrow(pc - 1, new NullReferenceException());
 							break;
 						}
-						object [] array = (object[])arrSE.AsObject();
+						Array array = (Array)arrSE.AsObject();
 						if (index < 0 || index >= array.Length)
 						{
 							interpretedThrow(pc - 1, new IndexOutOfRangeException());
 							break;
 						}
 						CilMetadataTokenInfo elemMeta = box.metadatas[otyp];
+						object value;
 						if( elemMeta.nativeTypeIsCilboxProxy || elemMeta.nativeType == null )
 						{
 							// This actually gets the value in valSE, and converts it to the int/float/native handle, etc. based on "this" box.
-							array[index] = valSE.AsObject( box );
+							value = valSE.AsObject( box );
 						}
 						else
 						{
-							array[index] = Convert.ChangeType( valSE.AsObject(), elemMeta.nativeType );  // This shouldn't be type changing.s
+							value = valSE.AsObject();
 						}
+
+						Type targetElementType = array.GetType().GetElementType();
+						if( targetElementType != null && targetElementType != typeof(object) && value != null && !targetElementType.IsInstanceOfType( value ) )
+						{
+							if( targetElementType.IsEnum )
+							{
+								value = Enum.ToObject( targetElementType, value );
+							}
+							else
+							{
+								if( value.GetType().IsEnum )
+									value = Convert.ChangeType( value, Enum.GetUnderlyingType( value.GetType() ) );
+								value = Convert.ChangeType( value, targetElementType );
+							}
+						}
+
+						array.SetValue( value, index );
 						break;
 					}
 					case 0xA5: // unbox.any

--- a/Packages/com.cnlohr.cilbox/CilboxAvatar.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxAvatar.cs
@@ -103,11 +103,19 @@ namespace Cilbox
 
 			if( declaringType == typeof(UnityEngine.GameObject) && name != "SetActive" ) return false;
 
+			// UnityEngine.Object.Instantiate spawns a prefab tree verbatim, bypassing
+			// host sanitization. A cilbox script can reference an unsanitized prefab
+			// from a serialized field and its UnityEvents (e.g. Button.onClick ->
+			// Application.OpenURL) execute outside the sandbox. Block all variants.
+			if( declaringType == typeof(UnityEngine.Object) &&
+				( name == "Instantiate" || name == "InstantiateAsync" ) )
+				return false;
+
 			if( name.Contains( "Invoke" ) ) return false;
 			return true;
 		}
 
-        public override bool GetComponentTypeOverride(string sType, out Type t)
+        public override bool GetTypeOverride(string sType, out Type t)
         {
 			t = null;
             return false;

--- a/Packages/com.cnlohr.cilbox/CilboxProxy.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxProxy.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 #if UNITY_EDITOR
 using Unity.Profiling;
 #endif
+using System.Text;
 
 namespace Cilbox
 {
@@ -210,12 +211,19 @@ namespace Cilbox
 				new ProfilerMarker( "Initialize " + className ).Auto();
 #endif
 
-				GameObject obj = gameObject;
-				initialLoadPath = "/" + obj.name;
-				while (obj.transform.parent != null)
+				// Build initialLoadPath in O(n) — the old "/" + name + path concat was O(depth^2) per proxy.
 				{
-					obj = obj.transform.parent.gameObject;
-					initialLoadPath = "/" + obj.name + initialLoadPath;
+					Transform cur = transform;
+					List<string> parts = new List<string>(8);
+					while (cur != null)
+					{
+						parts.Add(cur.gameObject.name);
+						cur = cur.parent;
+					}
+					StringBuilder sb = new StringBuilder(64);
+					for (int i = parts.Count - 1; i >= 0; i--)
+						sb.Append('/').Append(parts[i]);
+					initialLoadPath = sb.ToString();
 				}
 
 				if( string.IsNullOrEmpty( className ) )
@@ -264,31 +272,32 @@ namespace Cilbox
 				}
 
 				// Populate fields[]
-				fields = new StackElement[cls.instanceFieldNames.Length];
+				int fieldCount = cls.instanceFieldNames.Length;
+				fields = new StackElement[fieldCount];
 
 				Serializee [] d = new Serializee( Convert.FromBase64String( serializedObjectData ), Serializee.ElementType.Map ).AsArray();
 
-				Serializee [] matchingSerializeeInstanceField = new Serializee[cls.instanceFieldNames.Length];
+				Serializee [] matchingSerializeeInstanceField = new Serializee[fieldCount];
+				Dictionary< String, Serializee > [] matchingDicts = new Dictionary< String, Serializee >[fieldCount];
 				foreach( Serializee s in d )
 				{
 					// Go over the root objects, to see which ones slot in and how.
+					// Cache the parsed dict so the load pass below doesn't reparse.
 					Dictionary< String, Serializee > dict = s.AsMap();
-					Serializee val;
-					Serializee miid;
-					if( dict.TryGetValue( "t", out val ) && dict.TryGetValue( "miid", out miid ) )
+					if( dict.ContainsKey( "t" ) && dict.TryGetValue( "miid", out Serializee miid ) )
 					{
-						UInt32 nMIID = UInt32.MaxValue;
-						if( UInt32.TryParse( miid.AsString(), out nMIID ) &&
-							nMIID < matchingSerializeeInstanceField.Length )
+						if( UInt32.TryParse( miid.AsString(), out UInt32 nMIID ) &&
+							nMIID < fieldCount )
 						{
 							matchingSerializeeInstanceField[nMIID] = s;
+							matchingDicts[nMIID] = dict;
 						}
 					}
 				}
 
 				// Preinitialize every field to its CLR default value so that non-serialized fields
 				// (especially UnityEngine.Object references) are not left as implicit StackType.Boolean.
-				for( int i = 0; i < cls.instanceFieldNames.Length; i++ )
+				for( int i = 0; i < fieldCount; i++ )
 				{
 					Type fieldType = cls.instanceFieldTypes[i];
 					// Maybe need to GetComponentTypeOverride here as well?  Maybe not, since that should only be for actual UnityEngine.Objects, which should be null at this point if they are contraband.
@@ -332,14 +341,14 @@ namespace Cilbox
 				box.InterpretIID( cls, this, ImportFunctionID.dotCtor, null );
 
 				// load serialized fields.
-				for( int i = 0; i < cls.instanceFieldNames.Length; i++ )
+				for( int i = 0; i < fieldCount; i++ )
 				{
 					Serializee s = matchingSerializeeInstanceField[i];
 
 					if( s == null ) { /* Debug.Log( $"Skipping {i} {cls.instanceFieldNames[i]}" ); */ continue; }
 
 					object o;
-					bool bIsObject = LoadObjectFromSerializee( s, out o, cls.instanceFieldNames[i], cls.instanceFieldTypes[i], true );
+					bool bIsObject = LoadObjectFromSerializee( s, out o, cls.instanceFieldNames[i], cls.instanceFieldTypes[i], true, matchingDicts[i] );
 					if( bIsObject )
 						fields[i].LoadObject( o );
 					else
@@ -347,6 +356,10 @@ namespace Cilbox
 				}
 
 				proxyWasSetup = true;
+				// Release the serialized blob and original object list — they're only needed during load
+				// and the proxyWasSetup guard above prevents re-entry. Keeps ~a kB per proxy off the GC heap.
+				serializedObjectData = null;
+				fieldsObjects = null;
 				if (verboseLogging)
 					Debug.Log( $"RuntimeProxyLoad complete for class {className}" );
 			}
@@ -358,9 +371,10 @@ namespace Cilbox
 
 
 		// Returns: true if is object, otherwise is primitive.
-		private bool LoadObjectFromSerializee( Serializee s, out object oOut, String rootFieldName, Type inType, bool root )
+		// `dict` may be supplied by callers that already parsed the Serializee to avoid a redundant AsMap allocation.
+		private bool LoadObjectFromSerializee( Serializee s, out object oOut, String rootFieldName, Type inType, bool root, Dictionary< String, Serializee > dict = null )
 		{
-			Dictionary< String, Serializee > dict = s.AsMap();
+			if( dict == null ) dict = s.AsMap();
 
 			Serializee setype;
 			if( dict.TryGetValue( "t", out setype ) )
@@ -444,11 +458,13 @@ namespace Cilbox
 
 						Array arr = Array.CreateInstance( t, aLen );
 
-						int j;
-						for( j = 0; j < aLen; j++ )
+						// Hoist AsArray out of the loop — it previously re-parsed seAD and allocated
+						// a fresh Serializee[] of size aLen on every iteration (O(aLen^2) GC).
+						Serializee [] adArr = seAD.AsArray();
+						for( int j = 0; j < aLen; j++ )
 						{
 							object o;
-							LoadObjectFromSerializee( seAD.AsArray()[j], out o, rootFieldName, t, false );
+							LoadObjectFromSerializee( adArr[j], out o, rootFieldName, t, false );
 							arr.SetValue( o, j );
 						}
 

--- a/Packages/com.cnlohr.cilbox/CilboxProxy.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxProxy.cs
@@ -24,6 +24,7 @@ namespace Cilbox
 		public String initialLoadPath;
 
 		private bool proxyWasSetup = false;
+		private bool proxyLoadInProgress = false;
 
 		private void ProxyDebugLog( string message )
 		{
@@ -193,160 +194,168 @@ namespace Cilbox
 		{
 			//Debug.Log( "Runtime Proxy Load " + proxyWasSetup + " " + transform.name + " " + className );
 			if( proxyWasSetup ) return;
+			if( proxyLoadInProgress ) return;
 			if (box == null) return;
-			box.BoxInitialize(); // In case it is not yet initialized.
-			bool verboseLogging = box.verboseLogging;
+			proxyLoadInProgress = true;
+			try
+			{
+				box.BoxInitialize(); // In case it is not yet initialized.
+				bool verboseLogging = box.verboseLogging;
 
 #if UNITY_EDITOR
-			new ProfilerMarker($"Initialize {className}").Auto();
+				new ProfilerMarker($"Initialize {className}").Auto();
 #endif
-            var sb = new System.Text.StringBuilder("/" + transform.name);
-            Transform aparent = transform.parent;
-            while (aparent != null)
-            {
-                sb.Insert(0, aparent.name).Insert(0, '/');
-                aparent = aparent.parent;
-            }
-            initialLoadPath = sb.ToString();
-
-            Debug.Log($"initialLoadPath {initialLoadPath}");
-            if (string.IsNullOrEmpty(className))
-			{
-				Debug.LogError( $"[CilboxProxy:{gameObject.name}] RuntimeProxyLoad aborted: class {className} was not found in Cilbox assembly data." );
-				return;
-			}
-
-			cls = box.GetClass( className );
-
-			runtimeFieldsObjects = fieldsObjects != null ? new List<UnityEngine.Object>(fieldsObjects) : new List<UnityEngine.Object>();
-
-			// First thing: Go through any references that are prohibited.
-			for( int i = 0; i < runtimeFieldsObjects.Count; i++ )
-			{
-				UnityEngine.Object o = runtimeFieldsObjects[i];
-				if (o == null)
+				var sb = new System.Text.StringBuilder("/" + transform.name);
+				Transform aparent = transform.parent;
+				while (aparent != null)
 				{
-					// If it's null, there's nothing to safety-check.
-					continue;
+					sb.Insert(0, aparent.name).Insert(0, '/');
+					aparent = aparent.parent;
 				}
-				Type t = o.GetType();
-				if(box.GetTypeOverride( t.FullName, out Type overrideType )) {
-					Debug.Log( $"RuntimeProxyLoad: Override {t.FullName} with {overrideType.FullName}" );
-					t = overrideType;
-					if(typeof(CilboxShim).IsAssignableFrom(t) && runtimeFieldsObjects[i] is Component gameObjectComponent)
+				initialLoadPath = sb.ToString();
+
+				if (string.IsNullOrEmpty(className))
+				{
+					Debug.LogError( $"[CilboxProxy:{gameObject.name}] RuntimeProxyLoad aborted: class {className} was not found in Cilbox assembly data." );
+					return;
+				}
+
+				cls = box.GetClass( className );
+
+				runtimeFieldsObjects = fieldsObjects != null ? new List<UnityEngine.Object>(fieldsObjects) : new List<UnityEngine.Object>();
+
+				// First thing: Go through any references that are prohibited.
+				for( int i = 0; i < runtimeFieldsObjects.Count; i++ )
+				{
+					UnityEngine.Object o = runtimeFieldsObjects[i];
+					if (o == null)
 					{
-						GameObject gameObject = gameObjectComponent.gameObject;
-						Component component;
-						if(gameObject.TryGetComponent(t, out Component c)) {
-							component = c;
-						} else
+						// If it's null, there's nothing to safety-check.
+						continue;
+					}
+					Type t = o.GetType();
+					if(box.GetTypeOverride( t.FullName, out Type overrideType )) {
+						Debug.Log( $"RuntimeProxyLoad: Override {t.FullName} with {overrideType.FullName}" );
+						t = overrideType;
+						if(typeof(CilboxShim).IsAssignableFrom(t) && runtimeFieldsObjects[i] is Component gameObjectComponent)
 						{
-							component = gameObject.AddComponent(t);
+							GameObject gameObject = gameObjectComponent.gameObject;
+							Component component;
+							if(gameObject.TryGetComponent(t, out Component c)) {
+								component = c;
+							} else
+							{
+								component = gameObject.AddComponent(t);
+							}
+							runtimeFieldsObjects[i] = component;
 						}
-						runtimeFieldsObjects[i] = component;
 					}
-				}
-				if( t == typeof( CilboxProxy ) )
-				{
-					// If it's another cilbox proxy, it's OK.
-				}
-				else if( !box.CheckTypeAllowed( t.FullName ) )
-				{
-					Debug.LogWarning( $"Contraband found in script {className} field ID {i}: {o.GetType()}" );
-					runtimeFieldsObjects[i] = null;
-				}
-			}
-
-			// Populate fields[]
-			int fieldCount = cls.instanceFieldNames.Length;
-			fields = new StackElement[fieldCount];
-
-			Serializee [] d = new Serializee( Convert.FromBase64String( serializedObjectData ), Serializee.ElementType.Map ).AsArray();
-
-			Serializee [] matchingSerializeeInstanceField = new Serializee[fieldCount];
-			Dictionary< String, Serializee > [] matchingDicts = new Dictionary< String, Serializee >[fieldCount];
-			foreach( Serializee s in d )
-			{
-				// Go over the root objects, to see which ones slot in and how.
-				// Cache the parsed dict so the load pass below doesn't reparse.
-				Dictionary< String, Serializee > dict = s.AsMap();
-				if( dict.ContainsKey( "t" ) && dict.TryGetValue( "miid", out Serializee miid ) )
-				{
-					if( UInt32.TryParse( miid.AsString(), out UInt32 nMIID ) &&
-						nMIID < fieldCount )
+					if( t == typeof( CilboxProxy ) )
 					{
-						matchingSerializeeInstanceField[nMIID] = s;
-						matchingDicts[nMIID] = dict;
+						// If it's another cilbox proxy, it's OK.
 					}
-				}
-			}
-
-			// Preinitialize every field to its CLR default value so that non-serialized fields
-			// (especially UnityEngine.Object references) are not left as implicit StackType.Boolean.
-			for( int i = 0; i < fieldCount; i++ )
-			{
-				Type fieldType = cls.instanceFieldTypes[i];
-				// Maybe need to GetComponentTypeOverride here as well?  Maybe not, since that should only be for actual UnityEngine.Objects, which should be null at this point if they are contraband.
-				if( fieldType == null )
-				{
-					fields[i].LoadObject( null );
-					continue;
-				}
-				StackType st = StackElement.StackTypeFromType( fieldType );
-				if( st < StackType.Object )
-				{
-					fields[i].type = st;
-					if (verboseLogging)
-						ProxyDebugLog( $"Default field init {cls.instanceFieldNames[i]} <- default({fieldType})" );
-				}
-				else if( fieldType.IsValueType )
-				{
-					try
+					else if( !box.CheckTypeAllowed( t.FullName ) )
 					{
-						// We clean the fieldtype before https://github.com/cnlohr/cilbox/blob/fc608341d293186e0aacf519ea9f0beb43d42cee/Packages/com.cnlohr.cilbox/Cilbox.cs#L1389C40-L1389C67
-						object defaultValue = Activator.CreateInstance( fieldType );
-						fields[i].LoadObject( defaultValue );
-						if (verboseLogging)
-							ProxyDebugLog( $"Default field init {cls.instanceFieldNames[i]} <- default({fieldType}) [boxed]" );
+						Debug.LogWarning( $"Contraband found in script {className} field ID {i}: {o.GetType()}" );
+						runtimeFieldsObjects[i] = null;
 					}
-					catch( Exception e )
+				}
+
+				// Populate fields[]
+				int fieldCount = cls.instanceFieldNames.Length;
+				fields = new StackElement[fieldCount];
+
+				Serializee [] d = new Serializee( Convert.FromBase64String( serializedObjectData ), Serializee.ElementType.Map ).AsArray();
+
+				Serializee [] matchingSerializeeInstanceField = new Serializee[fieldCount];
+				Dictionary< String, Serializee > [] matchingDicts = new Dictionary< String, Serializee >[fieldCount];
+				foreach( Serializee s in d )
+				{
+					// Go over the root objects, to see which ones slot in and how.
+					// Cache the parsed dict so the load pass below doesn't reparse.
+					Dictionary< String, Serializee > dict = s.AsMap();
+					if( dict.ContainsKey( "t" ) && dict.TryGetValue( "miid", out Serializee miid ) )
+					{
+						if( UInt32.TryParse( miid.AsString(), out UInt32 nMIID ) &&
+							nMIID < fieldCount )
+						{
+							matchingSerializeeInstanceField[nMIID] = s;
+							matchingDicts[nMIID] = dict;
+						}
+					}
+				}
+
+				// Preinitialize every field to its CLR default value so that non-serialized fields
+				// (especially UnityEngine.Object references) are not left as implicit StackType.Boolean.
+				for( int i = 0; i < fieldCount; i++ )
+				{
+					Type fieldType = cls.instanceFieldTypes[i];
+					// Maybe need to GetComponentTypeOverride here as well?  Maybe not, since that should only be for actual UnityEngine.Objects, which should be null at this point if they are contraband.
+					if( fieldType == null )
 					{
 						fields[i].LoadObject( null );
-						Debug.LogWarning( $"[CilboxProxy:{gameObject.name}] Failed to create default value for {cls.instanceFieldNames[i]} ({fieldType}): {e.Message}" );
+						continue;
+					}
+					StackType st = StackElement.StackTypeFromType( fieldType );
+					if( st < StackType.Object )
+					{
+						fields[i].type = st;
+						if (verboseLogging)
+							ProxyDebugLog( $"Default field init {cls.instanceFieldNames[i]} <- default({fieldType})" );
+					}
+					else if( fieldType.IsValueType )
+					{
+						try
+						{
+							// We clean the fieldtype before https://github.com/cnlohr/cilbox/blob/fc608341d293186e0aacf519ea9f0beb43d42cee/Packages/com.cnlohr.cilbox/Cilbox.cs#L1389C40-L1389C67
+							object defaultValue = Activator.CreateInstance( fieldType );
+							fields[i].LoadObject( defaultValue );
+							if (verboseLogging)
+								ProxyDebugLog( $"Default field init {cls.instanceFieldNames[i]} <- default({fieldType}) [boxed]" );
+						}
+						catch( Exception e )
+						{
+							fields[i].LoadObject( null );
+							Debug.LogWarning( $"[CilboxProxy:{gameObject.name}] Failed to create default value for {cls.instanceFieldNames[i]} ({fieldType}): {e.Message}" );
+						}
+					}
+					else
+					{
+						fields[i].LoadObject( null );
+						if (verboseLogging)
+							ProxyDebugLog( $"Default field init {cls.instanceFieldNames[i]} <- null" );
 					}
 				}
-				else
+
+				// Call interpreted constructor.
+				box.InterpretIID( cls, this, ImportFunctionID.dotCtor, null );
+
+				// load serialized fields.
+				for( int i = 0; i < fieldCount; i++ )
 				{
-					fields[i].LoadObject( null );
-					if (verboseLogging)
-						ProxyDebugLog( $"Default field init {cls.instanceFieldNames[i]} <- null" );
+					Serializee s = matchingSerializeeInstanceField[i];
+
+					if( s == null ) { /* Debug.Log( $"Skipping {i} {cls.instanceFieldNames[i]}" ); */ continue; }
+
+					object o;
+					bool bIsObject = LoadObjectFromSerializee( s, out o, cls.instanceFieldNames[i], cls.instanceFieldTypes[i], true, matchingDicts[i] );
+					if( bIsObject )
+						fields[i].LoadObject( o );
+					else
+						fields[i].Load( o );
 				}
+
+
+				proxyWasSetup = true;
+				runtimeFieldsObjects = null;
+				serializedObjectData = null;
+				if (verboseLogging)
+					Debug.Log( $"RuntimeProxyLoad complete for class {className}" );
 			}
-
-			// Call interpreted constructor.
-			box.InterpretIID( cls, this, ImportFunctionID.dotCtor, null );
-
-			// load serialized fields.
-			for( int i = 0; i < fieldCount; i++ )
+			finally
 			{
-				Serializee s = matchingSerializeeInstanceField[i];
-
-				if( s == null ) { /* Debug.Log( $"Skipping {i} {cls.instanceFieldNames[i]}" ); */ continue; }
-
-				object o;
-				bool bIsObject = LoadObjectFromSerializee( s, out o, cls.instanceFieldNames[i], cls.instanceFieldTypes[i], true, matchingDicts[i] );
-				if( bIsObject )
-					fields[i].LoadObject( o );
-				else
-					fields[i].Load( o );
+				proxyLoadInProgress = false;
 			}
-
-
-			proxyWasSetup = true;
-			runtimeFieldsObjects = null;
-			serializedObjectData = null;
-			if (verboseLogging)
-				Debug.Log( $"RuntimeProxyLoad complete for class {className}" );
 		}
 
 

--- a/Packages/com.cnlohr.cilbox/CilboxProxy.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxProxy.cs
@@ -1,15 +1,11 @@
 using UnityEngine;
 using System;
-
-using System.Collections;
-using System.Collections.Specialized;
 using System.Collections.Generic;
 using System.Reflection;
 
 #if UNITY_EDITOR
 using Unity.Profiling;
 #endif
-using System.Text;
 
 namespace Cilbox
 {
@@ -17,6 +13,7 @@ namespace Cilbox
 	{
 		public StackElement [] fields;
 		public List< UnityEngine.Object > fieldsObjects;  // This is generally only held during saving and loading, not in use.
+		[NonSerialized] private List< UnityEngine.Object > runtimeFieldsObjects;
 
 		public CilboxClass cls;
 		public Cilbox box;
@@ -27,7 +24,6 @@ namespace Cilbox
 		public String initialLoadPath;
 
 		private bool proxyWasSetup = false;
-		private bool proxyLoadInProgress = false;
 
 		private void ProxyDebugLog( string message )
 		{
@@ -197,176 +193,160 @@ namespace Cilbox
 		{
 			//Debug.Log( "Runtime Proxy Load " + proxyWasSetup + " " + transform.name + " " + className );
 			if( proxyWasSetup ) return;
-			if( proxyLoadInProgress ) return;
 			if (box == null) return;
-			bool verboseLogging = false;
-			proxyLoadInProgress = true;
-
-			try
-			{
-				box.BoxInitialize(); // In case it is not yet initialized.
-				verboseLogging = box.verboseLogging;
+			box.BoxInitialize(); // In case it is not yet initialized.
+			bool verboseLogging = box.verboseLogging;
 
 #if UNITY_EDITOR
-				new ProfilerMarker( "Initialize " + className ).Auto();
+			new ProfilerMarker($"Initialize {className}").Auto();
 #endif
+            var sb = new System.Text.StringBuilder("/" + transform.name);
+            Transform aparent = transform.parent;
+            while (aparent != null)
+            {
+                sb.Insert(0, aparent.name).Insert(0, '/');
+                aparent = aparent.parent;
+            }
+            initialLoadPath = sb.ToString();
 
-				// Build initialLoadPath in O(n) — the old "/" + name + path concat was O(depth^2) per proxy.
-				{
-					Transform cur = transform;
-					List<string> parts = new List<string>(8);
-					while (cur != null)
-					{
-						parts.Add(cur.gameObject.name);
-						cur = cur.parent;
-					}
-					StringBuilder sb = new StringBuilder(64);
-					for (int i = parts.Count - 1; i >= 0; i--)
-						sb.Append('/').Append(parts[i]);
-					initialLoadPath = sb.ToString();
-				}
-
-				if( string.IsNullOrEmpty( className ) )
-				{
-					Debug.LogError( $"[CilboxProxy:{gameObject.name}] RuntimeProxyLoad aborted: class {className} was not found in Cilbox assembly data." );
-					return;
-				}
-
-				cls = box.GetClass( className );
-
-				// First thing: Go through any references that are prohibited.
-				for( int i = 0; i < fieldsObjects.Count; i++ )
-				{
-					UnityEngine.Object o = fieldsObjects[i];
-					if (o == null)
-					{
-						// If it's null, there's nothing to safety-check.
-						continue;
-					}
-					Type t = o.GetType();
-					if(box.GetComponentTypeOverride( t.FullName, out Type overrideType )) {
-						Debug.Log( $"RuntimeProxyLoad: Override {t.FullName} with {overrideType.FullName}" );
-						t = overrideType;
-						if(typeof(CilboxShim).IsAssignableFrom(t) && fieldsObjects[i] is Component gameObjectComponent)
-						{
-							GameObject gameObject = gameObjectComponent.gameObject;
-							Component component;
-							if(gameObject.TryGetComponent(t, out Component c)) {
-								component = c;
-							} else
-							{
-								component = gameObject.AddComponent(t);
-							}
-							fieldsObjects[i] = component;
-						}
-					}
-					if( t == typeof( CilboxProxy ) )
-					{
-						// If it's another cilbox proxy, it's OK.
-					}
-					else if( !box.CheckTypeAllowed( t.FullName ) )
-					{
-						Debug.LogWarning( $"Contraband found in script {className} field ID {i}: {o.GetType()}" );
-						fieldsObjects[i] = null;
-					}
-				}
-
-				// Populate fields[]
-				int fieldCount = cls.instanceFieldNames.Length;
-				fields = new StackElement[fieldCount];
-
-				Serializee [] d = new Serializee( Convert.FromBase64String( serializedObjectData ), Serializee.ElementType.Map ).AsArray();
-
-				Serializee [] matchingSerializeeInstanceField = new Serializee[fieldCount];
-				Dictionary< String, Serializee > [] matchingDicts = new Dictionary< String, Serializee >[fieldCount];
-				foreach( Serializee s in d )
-				{
-					// Go over the root objects, to see which ones slot in and how.
-					// Cache the parsed dict so the load pass below doesn't reparse.
-					Dictionary< String, Serializee > dict = s.AsMap();
-					if( dict.ContainsKey( "t" ) && dict.TryGetValue( "miid", out Serializee miid ) )
-					{
-						if( UInt32.TryParse( miid.AsString(), out UInt32 nMIID ) &&
-							nMIID < fieldCount )
-						{
-							matchingSerializeeInstanceField[nMIID] = s;
-							matchingDicts[nMIID] = dict;
-						}
-					}
-				}
-
-				// Preinitialize every field to its CLR default value so that non-serialized fields
-				// (especially UnityEngine.Object references) are not left as implicit StackType.Boolean.
-				for( int i = 0; i < fieldCount; i++ )
-				{
-					Type fieldType = cls.instanceFieldTypes[i];
-					// Maybe need to GetComponentTypeOverride here as well?  Maybe not, since that should only be for actual UnityEngine.Objects, which should be null at this point if they are contraband.
-					if( fieldType == null )
-					{
-						fields[i].LoadObject( null );
-						continue;
-					}
-					StackType st = StackElement.StackTypeFromType( fieldType );
-					if( st < StackType.Object )
-					{
-						fields[i].type = st;
-						if (verboseLogging)
-							ProxyDebugLog( $"Default field init {cls.instanceFieldNames[i]} <- default({fieldType})" );
-					}
-					else if( fieldType.IsValueType )
-					{
-						try
-						{
-							// We clean the fieldtype before https://github.com/cnlohr/cilbox/blob/fc608341d293186e0aacf519ea9f0beb43d42cee/Packages/com.cnlohr.cilbox/Cilbox.cs#L1389C40-L1389C67
-							object defaultValue = Activator.CreateInstance( fieldType );
-							fields[i].LoadObject( defaultValue );
-							if (verboseLogging)
-								ProxyDebugLog( $"Default field init {cls.instanceFieldNames[i]} <- default({fieldType}) [boxed]" );
-						}
-						catch( Exception e )
-						{
-							fields[i].LoadObject( null );
-							Debug.LogWarning( $"[CilboxProxy:{gameObject.name}] Failed to create default value for {cls.instanceFieldNames[i]} ({fieldType}): {e.Message}" );
-						}
-					}
-					else
-					{
-						fields[i].LoadObject( null );
-						if (verboseLogging)
-							ProxyDebugLog( $"Default field init {cls.instanceFieldNames[i]} <- null" );
-					}
-				}
-
-				// Call interpreted constructor.
-				box.InterpretIID( cls, this, ImportFunctionID.dotCtor, null );
-
-				// load serialized fields.
-				for( int i = 0; i < fieldCount; i++ )
-				{
-					Serializee s = matchingSerializeeInstanceField[i];
-
-					if( s == null ) { /* Debug.Log( $"Skipping {i} {cls.instanceFieldNames[i]}" ); */ continue; }
-
-					object o;
-					bool bIsObject = LoadObjectFromSerializee( s, out o, cls.instanceFieldNames[i], cls.instanceFieldTypes[i], true, matchingDicts[i] );
-					if( bIsObject )
-						fields[i].LoadObject( o );
-					else
-						fields[i].Load( o );
-				}
-
-				proxyWasSetup = true;
-				// Release the serialized blob and original object list — they're only needed during load
-				// and the proxyWasSetup guard above prevents re-entry. Keeps ~a kB per proxy off the GC heap.
-				serializedObjectData = null;
-				fieldsObjects = null;
-				if (verboseLogging)
-					Debug.Log( $"RuntimeProxyLoad complete for class {className}" );
-			}
-			finally
+            Debug.Log($"initialLoadPath {initialLoadPath}");
+            if (string.IsNullOrEmpty(className))
 			{
-				proxyLoadInProgress = false;
+				Debug.LogError( $"[CilboxProxy:{gameObject.name}] RuntimeProxyLoad aborted: class {className} was not found in Cilbox assembly data." );
+				return;
 			}
+
+			cls = box.GetClass( className );
+
+			runtimeFieldsObjects = fieldsObjects != null ? new List<UnityEngine.Object>(fieldsObjects) : new List<UnityEngine.Object>();
+
+			// First thing: Go through any references that are prohibited.
+			for( int i = 0; i < runtimeFieldsObjects.Count; i++ )
+			{
+				UnityEngine.Object o = runtimeFieldsObjects[i];
+				if (o == null)
+				{
+					// If it's null, there's nothing to safety-check.
+					continue;
+				}
+				Type t = o.GetType();
+				if(box.GetTypeOverride( t.FullName, out Type overrideType )) {
+					Debug.Log( $"RuntimeProxyLoad: Override {t.FullName} with {overrideType.FullName}" );
+					t = overrideType;
+					if(typeof(CilboxShim).IsAssignableFrom(t) && runtimeFieldsObjects[i] is Component gameObjectComponent)
+					{
+						GameObject gameObject = gameObjectComponent.gameObject;
+						Component component;
+						if(gameObject.TryGetComponent(t, out Component c)) {
+							component = c;
+						} else
+						{
+							component = gameObject.AddComponent(t);
+						}
+						runtimeFieldsObjects[i] = component;
+					}
+				}
+				if( t == typeof( CilboxProxy ) )
+				{
+					// If it's another cilbox proxy, it's OK.
+				}
+				else if( !box.CheckTypeAllowed( t.FullName ) )
+				{
+					Debug.LogWarning( $"Contraband found in script {className} field ID {i}: {o.GetType()}" );
+					runtimeFieldsObjects[i] = null;
+				}
+			}
+
+			// Populate fields[]
+			int fieldCount = cls.instanceFieldNames.Length;
+			fields = new StackElement[fieldCount];
+
+			Serializee [] d = new Serializee( Convert.FromBase64String( serializedObjectData ), Serializee.ElementType.Map ).AsArray();
+
+			Serializee [] matchingSerializeeInstanceField = new Serializee[fieldCount];
+			Dictionary< String, Serializee > [] matchingDicts = new Dictionary< String, Serializee >[fieldCount];
+			foreach( Serializee s in d )
+			{
+				// Go over the root objects, to see which ones slot in and how.
+				// Cache the parsed dict so the load pass below doesn't reparse.
+				Dictionary< String, Serializee > dict = s.AsMap();
+				if( dict.ContainsKey( "t" ) && dict.TryGetValue( "miid", out Serializee miid ) )
+				{
+					if( UInt32.TryParse( miid.AsString(), out UInt32 nMIID ) &&
+						nMIID < fieldCount )
+					{
+						matchingSerializeeInstanceField[nMIID] = s;
+						matchingDicts[nMIID] = dict;
+					}
+				}
+			}
+
+			// Preinitialize every field to its CLR default value so that non-serialized fields
+			// (especially UnityEngine.Object references) are not left as implicit StackType.Boolean.
+			for( int i = 0; i < fieldCount; i++ )
+			{
+				Type fieldType = cls.instanceFieldTypes[i];
+				// Maybe need to GetComponentTypeOverride here as well?  Maybe not, since that should only be for actual UnityEngine.Objects, which should be null at this point if they are contraband.
+				if( fieldType == null )
+				{
+					fields[i].LoadObject( null );
+					continue;
+				}
+				StackType st = StackElement.StackTypeFromType( fieldType );
+				if( st < StackType.Object )
+				{
+					fields[i].type = st;
+					if (verboseLogging)
+						ProxyDebugLog( $"Default field init {cls.instanceFieldNames[i]} <- default({fieldType})" );
+				}
+				else if( fieldType.IsValueType )
+				{
+					try
+					{
+						// We clean the fieldtype before https://github.com/cnlohr/cilbox/blob/fc608341d293186e0aacf519ea9f0beb43d42cee/Packages/com.cnlohr.cilbox/Cilbox.cs#L1389C40-L1389C67
+						object defaultValue = Activator.CreateInstance( fieldType );
+						fields[i].LoadObject( defaultValue );
+						if (verboseLogging)
+							ProxyDebugLog( $"Default field init {cls.instanceFieldNames[i]} <- default({fieldType}) [boxed]" );
+					}
+					catch( Exception e )
+					{
+						fields[i].LoadObject( null );
+						Debug.LogWarning( $"[CilboxProxy:{gameObject.name}] Failed to create default value for {cls.instanceFieldNames[i]} ({fieldType}): {e.Message}" );
+					}
+				}
+				else
+				{
+					fields[i].LoadObject( null );
+					if (verboseLogging)
+						ProxyDebugLog( $"Default field init {cls.instanceFieldNames[i]} <- null" );
+				}
+			}
+
+			// Call interpreted constructor.
+			box.InterpretIID( cls, this, ImportFunctionID.dotCtor, null );
+
+			// load serialized fields.
+			for( int i = 0; i < fieldCount; i++ )
+			{
+				Serializee s = matchingSerializeeInstanceField[i];
+
+				if( s == null ) { /* Debug.Log( $"Skipping {i} {cls.instanceFieldNames[i]}" ); */ continue; }
+
+				object o;
+				bool bIsObject = LoadObjectFromSerializee( s, out o, cls.instanceFieldNames[i], cls.instanceFieldTypes[i], true, matchingDicts[i] );
+				if( bIsObject )
+					fields[i].LoadObject( o );
+				else
+					fields[i].Load( o );
+			}
+
+
+			proxyWasSetup = true;
+			runtimeFieldsObjects = null;
+			serializedObjectData = null;
+			if (verboseLogging)
+				Debug.Log( $"RuntimeProxyLoad complete for class {className}" );
 		}
 
 
@@ -374,6 +354,7 @@ namespace Cilbox
 		// `dict` may be supplied by callers that already parsed the Serializee to avoid a redundant AsMap allocation.
 		private bool LoadObjectFromSerializee( Serializee s, out object oOut, String rootFieldName, Type inType, bool root, Dictionary< String, Serializee > dict = null )
 		{
+			List<UnityEngine.Object> objectSlots = runtimeFieldsObjects ?? fieldsObjects;
 			if( dict == null ) dict = s.AsMap();
 
 			Serializee setype;
@@ -386,7 +367,8 @@ namespace Cilbox
 					int iFO;
 					if( dict.TryGetValue( "fo", out seFO ) &&
 						Int32.TryParse( seFO.AsString(), out iFO ) &&
-						iFO < fieldsObjects.Count )
+						objectSlots != null &&
+						iFO < objectSlots.Count )
 					{
 						if (dict.TryGetValue("or", out var seOr))
 						{
@@ -398,7 +380,7 @@ namespace Cilbox
 							}
 						}
 
-						UnityEngine.Object o = fieldsObjects[iFO];
+						UnityEngine.Object o = objectSlots[iFO];
 
 						//Debug.Log( $"LOADING FIELD: {i} with {o}" );
 						if( o )
@@ -409,7 +391,7 @@ namespace Cilbox
 							oOut = o;
 
 							// Remove reference out of the fieldsObjects array.
-							fieldsObjects[iFO] = null;
+							objectSlots[iFO] = null;
 
 							return true;
 						}
@@ -417,7 +399,8 @@ namespace Cilbox
 					}
 					else
 					{
-						Debug.LogWarning( $"Failure to load object in field id:{rootFieldName} of {className} (slot parse failed or out of range, fieldsObjects count={fieldsObjects.Count})");
+						int objectSlotCount = objectSlots != null ? objectSlots.Count : 0;
+						Debug.LogWarning( $"Failure to load object in field id:{rootFieldName} of {className} (slot parse failed or out of range, fieldsObjects count={objectSlotCount})");
 					}
 				}
 				else if( sT[0] == 'a' )

--- a/Packages/com.cnlohr.cilbox/CilboxScene.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxScene.cs
@@ -112,13 +112,21 @@ namespace Cilbox
 			if( declaringType == typeof(UnityEngine.GameObject) &&
 				( name != "SetActive" && name != "GetComponents" ) ) return false;
 
+			// UnityEngine.Object.Instantiate spawns a prefab tree verbatim, bypassing
+			// host sanitization. A cilbox script can reference an unsanitized prefab
+			// from a serialized field and its UnityEvents (e.g. Button.onClick ->
+			// Application.OpenURL) execute outside the sandbox. Block all variants.
+			if( declaringType == typeof(UnityEngine.Object) &&
+				( name == "Instantiate" || name == "InstantiateAsync" ) )
+				return false;
+
 			if( declaringType == typeof(System.Type) ) return false;
 
 			if( name.Contains( "Invoke" ) ) return false;
 			return true;
 		}
 
-        public override bool GetComponentTypeOverride(string sType, out Type t)
+        public override bool GetTypeOverride(string sType, out Type t)
         {
 			t = null;
             return false;

--- a/Packages/com.cnlohr.cilbox/CilboxUsage.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxUsage.cs
@@ -67,8 +67,8 @@ namespace Cilbox
 			if( !bDisallowed ) goto disallowed;
 			if( mi != null ) return mi;
 
-			// Replace any delegate creations with their proxies.
-			if( typeof(Delegate).IsAssignableFrom(declaringType) )
+			// Replace delegate construction with cilbox-backed host delegates.
+			if( typeof(Delegate).IsAssignableFrom(declaringType) && name == ".ctor" )
 			{
 				int argct = declaringType.GenericTypeArguments.Length;
 				Type specific = typeof(CilboxPlatform);
@@ -385,7 +385,7 @@ namespace Cilbox
 			String typeName = ses["n"].AsString();
 			String assemblyName = ses["a"].AsString();
 			if( IsCilboxInternalType( typeName ) ) return null;
-			if(box.GetComponentTypeOverride( typeName, out Type overrideType )) {
+			if(box.GetTypeOverride( typeName, out Type overrideType )) {
 				Debug.Log( $"GetNativeTypeFromSerializee: Override {typeName} with {overrideType.FullName}" );
 				typeName = overrideType.FullName;
 				assemblyName = overrideType.Assembly.GetName().Name;
@@ -441,7 +441,7 @@ namespace Cilbox
 			if( ses.TryGetValue( "ut", out utSer ) ) return GetNativeTypeNameFromSerializee( utSer );
 			String typeName = ses["n"].AsString();
 			if( IsCilboxInternalType( typeName ) ) return typeName;
-			if(box.GetComponentTypeOverride( typeName, out Type overrideType )) {
+			if(box.GetTypeOverride( typeName, out Type overrideType )) {
 				Debug.Log( $"GetNativeTypeFromSerializee: Override {typeName} with {overrideType.FullName}" );
 				typeName = overrideType.FullName;
 			}
@@ -618,8 +618,25 @@ namespace Cilbox
 	{
 		// This is called only when creating a new action, not when it's called.
 		// T is the delegate, not the arguments of the delegate.
-		static public object ProxyForGeneratingActions<T>( CilboxProxy proxy, CilboxMethod method )
+		static public object ProxyForGeneratingActions<T>( CilboxProxy proxy, object methodOrDelegate )
 		{
+			if( methodOrDelegate is T existingTypedDelegate )
+			{
+				return existingTypedDelegate;
+			}
+
+			if( methodOrDelegate is Delegate existingDelegate &&
+				typeof(T).IsAssignableFrom( existingDelegate.GetType() ) )
+			{
+				return existingDelegate;
+			}
+
+			if( methodOrDelegate is not CilboxMethod method )
+			{
+				throw new ArgumentException(
+					$"ProxyForGeneratingActions expected a CilboxMethod or compatible delegate, got {methodOrDelegate?.GetType().FullName ?? "null"}" );
+			}
+
 			CilboxPlatform.DelegateRepackage rp = new CilboxPlatform.DelegateRepackage();
 			rp.meth = method;
 			rp.o = proxy;

--- a/Packages/com.cnlohr.cilbox/LICENSE
+++ b/Packages/com.cnlohr.cilbox/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) cnlohr
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Packages/com.cnlohr.cilbox/LICENSE
+++ b/Packages/com.cnlohr.cilbox/LICENSE
@@ -1,6 +1,8 @@
 MIT License
 
-Copyright (c) cnlohr
+Copyright (c) 2025 cnlohr
+Copyright (c) 2008 - 2015 Jb Evain (jbevain@gmail.com) (opcodes)
+Copyright (c) 2008 - 2011 Novell, Inc. (For original CIL code from cecil)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Packages/com.cnlohr.cilbox/LICENSE.meta
+++ b/Packages/com.cnlohr.cilbox/LICENSE.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: aec6b9135d229d64fa57d1bb8e6c3a77
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.cnlohr.cilbox/link.xml
+++ b/Packages/com.cnlohr.cilbox/link.xml
@@ -1,0 +1,70 @@
+<linker>
+	<assembly fullname="Cilbox">
+		<type fullname="Cilbox.CilboxPublicUtils" preserve="all"/>
+	</assembly>
+	<assembly fullname="mscorlib">
+		<type fullname="System.Array" preserve="all"/>
+		<type fullname="System.Boolean" preserve="all"/>
+		<type fullname="System.Byte" preserve="all"/>
+		<type fullname="System.Char" preserve="all"/>
+		<type fullname="System.DateTime" preserve="all"/>
+		<type fullname="System.DayOfWeek" preserve="all"/>
+		<type fullname="System.Double" preserve="all"/>
+		<type fullname="System.Int32" preserve="all"/>
+		<type fullname="System.Int64" preserve="all"/>
+		<type fullname="System.MathF" preserve="all"/>
+		<type fullname="System.Math" preserve="all"/>
+		<type fullname="System.Object" preserve="all"/>
+		<type fullname="System.Single" preserve="all"/>
+		<type fullname="System.String" preserve="all"/>
+		<type fullname="System.TimeSpan" preserve="all"/>
+		<type fullname="System.UInt16" preserve="all"/>
+		<type fullname="System.UInt32" preserve="all"/>
+		<type fullname="System.UInt64" preserve="all"/>
+		<type fullname="System.ValueTuple" preserve="all"/>
+		<type fullname="System.Void" preserve="all"/>
+		<type fullname="System.BitConverter" preserve="all"/>
+		<type fullname="System.Convert" preserve="all"/>
+		<type fullname="System.Exception" preserve="all"/>
+		<type fullname="System.Int16" preserve="all"/>
+		<type fullname="<PrivateImplementationDetails>" preserve="all"/>
+	</assembly>
+	<assembly fullname="netstandard">
+		<type fullname="System.Diagnostics.Stopwatch" preserve="all"/>
+	</assembly>
+	<assembly fullname="UnityEngine">
+		<type fullname="UnityEngine.Component" preserve="all"/>
+		<type fullname="UnityEngine.Debug" preserve="all"/>
+		<type fullname="UnityEngine.Events.UnityAction" preserve="all"/>
+		<type fullname="UnityEngine.Events.UnityEvent" preserve="all"/>
+		<type fullname="UnityEngine.GameObject" preserve="all"/>
+		<type fullname="UnityEngine.Material" preserve="all"/>
+		<type fullname="UnityEngine.MaterialPropertyBlock" preserve="all"/>
+		<type fullname="UnityEngine.Mathf" preserve="all"/>
+		<type fullname="UnityEngine.MeshRenderer" preserve="all"/>
+		<type fullname="UnityEngine.MonoBehaviour" preserve="all"/>
+		<type fullname="UnityEngine.Object" preserve="all"/>
+		<type fullname="UnityEngine.Random" preserve="all"/>
+		<type fullname="UnityEngine.Renderer" preserve="all"/>
+		<type fullname="UnityEngine.Time" preserve="all"/>
+		<type fullname="UnityEngine.Texture" preserve="all"/>
+		<type fullname="UnityEngine.TextAsset" preserve="all"/>
+		<type fullname="UnityEngine.Texture2D" preserve="all"/>
+		<type fullname="UnityEngine.Transform" preserve="all"/>
+		<type fullname="UnityEngine.Vector4" preserve="all"/>
+		<type fullname="UnityEngine.Vector3" preserve="all"/>
+		<type fullname="UnityEngine.AudioSource" preserve="all"/>
+		<type fullname="UnityEngine.AudioClip" preserve="all"/>
+		<type fullname="UnityEngine.Color" preserve="all"/>
+	</assembly>
+	<assembly fullname="UnityEngine.UI">
+		<type fullname="UnityEngine.UI.Button+ButtonClickedEvent" preserve="all"/>
+		<type fullname="UnityEngine.UI.Button" preserve="all"/>
+		<type fullname="UnityEngine.UI.InputField" preserve="all"/>
+		<type fullname="UnityEngine.UI.InputField+OnChangeEvent" preserve="all"/>
+		<type fullname="UnityEngine.UI.Scrollbar" preserve="all"/>
+		<type fullname="UnityEngine.UI.Selectable" preserve="all"/>
+		<type fullname="UnityEngine.UI.Slider" preserve="all"/>
+		<type fullname="UnityEngine.UI.Text" preserve="all"/>
+	</assembly>
+</linker>

--- a/Packages/com.cnlohr.cilbox/link.xml.meta
+++ b/Packages/com.cnlohr.cilbox/link.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b954768882abf192f9c4aa42480ae1e6
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -116,7 +116,7 @@ namespace TestCilbox
 			return true;
 		}
 
-        public override bool GetComponentTypeOverride(string sType, out Type t)
+        public override bool GetTypeOverride(string sType, out Type t)
         {
 			t = null;
             return false;

--- a/TestCilbox/UnityEngine.cs
+++ b/TestCilbox/UnityEngine.cs
@@ -208,12 +208,14 @@ namespace UnityEngine
 	public class Transform : Component
 	{
 		public Vector3 position;
-		public GameObject parent = null;
+		public Transform parent = null;
+		public string name => gameObject != null ? gameObject.name : null;
 	}
 
 	public class Component : Object
 	{
 		public GameObject gameObject = null;
+		public Transform transform => gameObject != null ? gameObject.transform : null;
 	}
 
 	public class GameObject : UnityEngine.Object
@@ -222,14 +224,20 @@ namespace UnityEngine
 		public List<Object> AllComponents = new List<Object>();
 		public String name;
 		public HideFlags hideFlags;
-		public Transform transform = new Transform();
+		private readonly Transform _transform = new Transform();
+		public Transform transform => _transform;
 
 		public T[] GetComponentsInChildren<T>( bool something ) { return AllComponents.ToArray().OfType<T>().ToArray(); }
 
 		public GameObject gameObject = null;
 
 		public static void Destroy( GameObject o ) { AllObjects.Remove( o ); }
-		public GameObject(String name) { this.name = name; GameObject.AllObjects.Add(this);  }
+		public GameObject(String name)
+		{
+			this.name = name;
+			this._transform.gameObject = this;
+			GameObject.AllObjects.Add(this);
+		}
 
 		public static GameObject Find( String s )
  		{


### PR DESCRIPTION
Went over the code changes from dooly's branch, and went over the test cases we had, fixed all the regressions that happened.
* Removed `stobj` opcode support in `Cilbox.cs`.
  * Effect on tests: private/out value-type writes stopped working. `TestCilbox`: `TryGetPrivateComplexOutPayload` failed with `Opcode 0x81 unimplemented`, which cascaded into unset validations for private complex out payloads, behaviour-array mutation checks, cross-behaviour exception tests, and an extra disable-count failure.
* Rewrote `stelem <typeTok>` to assume arrays are `object[]`.
  * `TestCilbox`: static initialization crashed on `System.Numerics.Vector2[]` with `InvalidCastException: Unable to cast object of type 'System.Numerics.Vector2[]' to type 'System.Object[]'`. The new implementation replaced generic `Array.SetValue(...)` handling with a hard cast to `object[]`, which is invalid for value-type arrays.
* Removed the proxy re-entrancy guard from `CilboxProxy.RuntimeProxyLoad()`.
  * `TestCilbox`: repeated `initialLoadPath` logging followed by deep recursive `RuntimeProxyLoad -> LoadObjectFromSerializee -> RuntimeProxyLoad` stack traces on the cycle root/child test objects. `proxyLoadInProgress` was removed, so proxy loading no longer short-circuited while a cycle was already being materialized.
  
## Changes
* Add more truthful `UnityEngine` stub to fit the new harness compatbility.