### PR TITLE
Add Nullable Check into cilbox.

### DIFF
--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -540,11 +540,35 @@ spiperf.Begin();
 
 								if (callthis == null)
 								{
-									interpretedThrow(pc - 1, new NullReferenceException());
-									break;
+									Type nullableUnderlyingType = Nullable.GetUnderlyingType(t);
+									if( nullableUnderlyingType != null )
+									{
+										switch( mi.Name )
+										{
+										case "get_HasValue":
+											iko = false;
+											break;
+										case "GetValueOrDefault":
+											iko = callpar.Length == 0 ? Activator.CreateInstance(nullableUnderlyingType) : callpar[0];
+											break;
+										case "get_Value":
+											interpretedThrow(pc - 1, new InvalidOperationException("Nullable object must have a value."));
+											break;
+										default:
+											interpretedThrow(pc - 1, new NullReferenceException());
+											break;
+										}
+									}
+									else
+									{
+										interpretedThrow(pc - 1, new NullReferenceException());
+									}
+									if( iko == null ) break;
 								}
-
-								iko = st.Invoke( callthis, callpar );
+								else
+								{
+									iko = st.Invoke( callthis, callpar );
+								}
 								if( seorig.type == StackType.Address  && callthis is not BoxedCilboxEnum ) // enums are immutable
 								{
 									seorig.DereferenceLoadAddress( callthis );

--- a/Packages/com.cnlohr.cilbox/CilboxUtil.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxUtil.cs
@@ -185,8 +185,7 @@ namespace Cilbox
 				{
 					return null;
 				}
-
-				return CoerceToObject(nullableUnderlyingType);
+				t = nullableUnderlyingType;
 			}
 
 			StackType rt = StackTypeFromType( t );

--- a/Packages/com.cnlohr.cilbox/CilboxUtil.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxUtil.cs
@@ -178,6 +178,17 @@ namespace Cilbox
 
 		public object CoerceToObject( Type t )
 		{
+			Type nullableUnderlyingType = Nullable.GetUnderlyingType(t);
+			if( nullableUnderlyingType != null )
+			{
+				if( type == StackType.Object && o == null )
+				{
+					return null;
+				}
+
+				return CoerceToObject(nullableUnderlyingType);
+			}
+
 			StackType rt = StackTypeFromType( t );
 
 			if( t.IsEnum && type < StackType.Object )

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -49,6 +49,7 @@ namespace TestCilbox
 			"System.Numerics.Vector2",
 			"System.Object",
 			"System.Nullable",
+			"System.Nullable`1",
 			"System.Single",
 			"System.String",
 			"System.TimeSpan",
@@ -258,6 +259,16 @@ namespace TestCilbox
 		public static void GetOutInt(out int i)
 		{
 			i = 42;
+		}
+
+		public static void GetOutNullableInt(out int? i)
+		{
+			i = 42;
+		}
+
+		public static void GetOutNullableIntNull(out int? i)
+		{
+			i = null;
 		}
 
 		public static string NullablePrimitiveSummary(bool? flag, int? count, float? scale)
@@ -752,6 +763,10 @@ namespace TestCilbox
 			Validator.Validate("NativeOutVec3", "(12, 8, 0)");
 			Validator.Validate("CilOutVec3", "(1, 2, 3)");
 			Validator.Validate("NativeOutInt", "42");
+			Validator.Validate("NativeOutNullableIntHasValue", "True");
+			Validator.Validate("NativeOutNullableIntValue", "42");
+			Validator.Validate("NativeOutNullableIntNullHasValue", "False");
+			Validator.Validate("NativeOutNullableIntNullValue", "0");
 			Validator.Validate("CilOutInt", "22");
 			Validator.Validate("NativeOutVec3AlreadyInit", "(12, 8, 0)");
 			Validator.Validate("NullablePrimitiveCoerceValues", "True, 42, 1.5");

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -48,6 +48,8 @@ namespace TestCilbox
 			"System.NullReferenceException",
 			"System.Numerics.Vector2",
 			"System.Object",
+			"System.Nullable",
+			"System.Nullable`1",
 			"System.Single",
 			"System.String",
 			"System.TimeSpan",
@@ -256,6 +258,14 @@ namespace TestCilbox
 		public static void GetOutInt(out int i)
 		{
 			i = 42;
+		}
+
+		public static string NullablePrimitiveSummary(bool? flag, int? count, float? scale)
+		{
+			string flagText = flag.HasValue ? flag.Value.ToString() : "null";
+			string countText = count.HasValue ? count.Value.ToString() : "null";
+			string scaleText = scale.HasValue ? scale.Value.ToString() : "null";
+			return flagText + ", " + countText + ", " + scaleText;
 		}
 	}
 
@@ -734,6 +744,8 @@ namespace TestCilbox
 			Validator.Validate("NativeOutInt", "42");
 			Validator.Validate("CilOutInt", "22");
 			Validator.Validate("NativeOutVec3AlreadyInit", "(12, 8, 0)");
+			Validator.Validate("NullablePrimitiveCoerceValues", "True, 42, 1.5");
+			Validator.Validate("NullablePrimitiveCoerceNulls", "null, null, null");
 			Validator.Validate("PrivateBoolOutSuccess", "True");
 			Validator.Validate("PrivateBoolOutInt", "1111");
 			Validator.Validate("PrivateBoolOutAlreadyInitSuccess", "True");

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -52,6 +52,7 @@ namespace TestCilbox
 			"System.Single",
 			"System.String",
 			"System.TimeSpan",
+			"System.Type",
 			"System.UInt16",
 			"System.UInt32",
 			"System.ValueTuple",
@@ -265,6 +266,16 @@ namespace TestCilbox
 			string countText = count.HasValue ? count.Value.ToString() : "null";
 			string scaleText = scale.HasValue ? scale.Value.ToString() : "null";
 			return flagText + ", " + countText + ", " + scaleText;
+		}
+
+		public static int? GetNullableInt()
+		{
+			return 42;
+		}
+
+		public static Type GetNullableIntReturnType()
+		{
+			return typeof(TestUtil).GetMethod(nameof(GetNullableInt)).ReturnType;
 		}
 	}
 
@@ -745,6 +756,8 @@ namespace TestCilbox
 			Validator.Validate("NativeOutVec3AlreadyInit", "(12, 8, 0)");
 			Validator.Validate("NullablePrimitiveCoerceValues", "True, 42, 1.5");
 			Validator.Validate("NullablePrimitiveCoerceNulls", "null, null, null");
+			Validator.Validate("NullableReturnTypeIsNullable", "True");
+			Validator.Validate("NullableReturnTypeUnderlying", "System.Int32");
 			Validator.Validate("PrivateBoolOutSuccess", "True");
 			Validator.Validate("PrivateBoolOutInt", "1111");
 			Validator.Validate("PrivateBoolOutAlreadyInitSuccess", "True");

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -49,7 +49,6 @@ namespace TestCilbox
 			"System.Numerics.Vector2",
 			"System.Object",
 			"System.Nullable",
-			"System.Nullable`1",
 			"System.Single",
 			"System.String",
 			"System.TimeSpan",

--- a/TestCilbox/TestCilboxable.cs
+++ b/TestCilbox/TestCilboxable.cs
@@ -538,6 +538,10 @@ namespace TestCilbox
 			Validator.Set("NativeOutVec3AlreadyInit", alreadyInit.ToString() );
 			Validator.Set("NullablePrimitiveCoerceValues", TestUtil.NullablePrimitiveSummary(true, 42, 1.5f) );
 			Validator.Set("NullablePrimitiveCoerceNulls", TestUtil.NullablePrimitiveSummary(null, null, null) );
+			Type nullableReturnType = TestUtil.GetNullableIntReturnType();
+			Type nullableUnderlyingType = Nullable.GetUnderlyingType(nullableReturnType);
+			Validator.Set("NullableReturnTypeIsNullable", (nullableUnderlyingType != null).ToString() );
+			Validator.Set("NullableReturnTypeUnderlying", nullableUnderlyingType.FullName );
 			bool privateOutSuccess = TryGetPrivateOutInt(out int privateOutInt);
 			Validator.Set("PrivateBoolOutSuccess", privateOutSuccess.ToString() );
 			Validator.Set("PrivateBoolOutInt", privateOutInt.ToString() );

--- a/TestCilbox/TestCilboxable.cs
+++ b/TestCilbox/TestCilboxable.cs
@@ -531,6 +531,12 @@ namespace TestCilbox
 			Validator.Set("CilOutVec3", outVec2.ToString() );
 			TestUtil.GetOutInt(out int outInt);
 			Validator.Set("NativeOutInt", outInt.ToString() );
+			TestUtil.GetOutNullableInt(out int? outNullableInt);
+			Validator.Set("NativeOutNullableIntHasValue", outNullableInt.HasValue.ToString() );
+			Validator.Set("NativeOutNullableIntValue", outNullableInt.GetValueOrDefault().ToString() );
+			TestUtil.GetOutNullableIntNull(out int? outNullableIntNull);
+			Validator.Set("NativeOutNullableIntNullHasValue", outNullableIntNull.HasValue.ToString() );
+			Validator.Set("NativeOutNullableIntNullValue", outNullableIntNull.GetValueOrDefault().ToString() );
 			TestOutInt(out int outInt2);
 			Validator.Set("CilOutInt", outInt2.ToString() );
 			Vector3 alreadyInit = new Vector3(5, 5, 5);

--- a/TestCilbox/TestCilboxable.cs
+++ b/TestCilbox/TestCilboxable.cs
@@ -536,6 +536,8 @@ namespace TestCilbox
 			Vector3 alreadyInit = new Vector3(5, 5, 5);
 			TestUtil.GetOutVec3(out alreadyInit);
 			Validator.Set("NativeOutVec3AlreadyInit", alreadyInit.ToString() );
+			Validator.Set("NullablePrimitiveCoerceValues", TestUtil.NullablePrimitiveSummary(true, 42, 1.5f) );
+			Validator.Set("NullablePrimitiveCoerceNulls", TestUtil.NullablePrimitiveSummary(null, null, null) );
 			bool privateOutSuccess = TryGetPrivateOutInt(out int privateOutInt);
 			Validator.Set("PrivateBoolOutSuccess", privateOutSuccess.ToString() );
 			Validator.Set("PrivateBoolOutInt", privateOutInt.ToString() );


### PR DESCRIPTION
When using a nullable, cilbox will crash with
```
Breakwarn: System.Exception: Error invalid type conversion from Boolean to System.Nullable`1[System.Boolean]
  at Cilbox.StackElement.CoerceToObject (System.Type t) [0x00447] in .\Packages\com.cnlohr.cilbox\CilboxUtil.cs:271 
  at Cilbox.CilboxMethod.InterpretInner (System.ArraySegment`1[T] stackBufferIn, System.ArraySegment`1[T] parametersIn) [0x01450] in .\Packages\com.cnlohr.cilbox\Cilbox.cs:535 ...
```
This is an underlying check, with regression test as well.