### PR TITLE
Reject negative serialized object slots

### DIFF
--- a/Packages/com.cnlohr.cilbox/CilboxProxy.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxProxy.cs
@@ -378,6 +378,7 @@ namespace Cilbox
 					if( dict.TryGetValue( "fo", out seFO ) &&
 						Int32.TryParse( seFO.AsString(), out iFO ) &&
 						objectSlots != null &&
+						iFO >= 0 &&
 						iFO < objectSlots.Count )
 					{
 						if (dict.TryGetValue("or", out var seOr))

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -347,6 +347,8 @@ namespace TestCilbox
 				Validator.AddCount($"CilboxDisabled_{box.GetType().FullName}");
 			};
 
+			ValidateNegativeFieldsObjectIndex();
+
 			GameObject go = new GameObject("MyObjectToProxy");
 			TestCilboxBehaviour b = go.CreateComponent<TestCilboxBehaviour>();
 
@@ -416,6 +418,7 @@ namespace TestCilbox
 				Validator.Validate( "Cycle Root Has Child", "True" );
 				Validator.Validate( "Cycle Child Has Root", "True" );
 				Validator.Validate( "Cycle Child BackRef Same", "True" );
+				Validator.Validate( "Negative fieldsObjects index", "ignored" );
 
 				Validator.Validate( "private instance filed", "555");
 				Validator.Validate( "public instance field", "556" );
@@ -768,6 +771,38 @@ namespace TestCilbox
 			}
 
 			return -1 * Validator.NumValidationErrors();
+		}
+
+		private static void ValidateNegativeFieldsObjectIndex()
+		{
+			Cilbox.CilboxProxy proxy = new Cilbox.CilboxProxy();
+			proxy.fieldsObjects = new List<UnityEngine.Object>();
+
+			Dictionary<string, Serializee> dict = new Dictionary<string, Serializee>();
+			dict["t"] = new Serializee("obj");
+			dict["fo"] = new Serializee("-1");
+			Serializee serialized = new Serializee(dict);
+
+			MethodInfo method = typeof(Cilbox.CilboxProxy).GetMethod(
+				"LoadObjectFromSerializee",
+				BindingFlags.Instance | BindingFlags.NonPublic);
+			if( method == null )
+			{
+				Validator.Set("Negative fieldsObjects index", "missing method");
+				return;
+			}
+
+			try
+			{
+				object[] args = new object[] { serialized, null, "badField", typeof(UnityEngine.Object), true, null };
+				object result = method.Invoke(proxy, args);
+				bool loaded = result is bool b && b;
+				Validator.Set("Negative fieldsObjects index", loaded ? "loaded" : "ignored");
+			}
+			catch (Exception e)
+			{
+				Validator.Set("Negative fieldsObjects index", e.GetType().Name);
+			}
 		}
 	}
 }


### PR DESCRIPTION
`LoadObjectFromSerializee` checked that parsed `fo` values were below the object slot count, but did not reject negative values. A negative value therefore reached the list indexer and raised `ArgumentOutOfRangeException` during proxy loading.

Changes:
- require `fo >= 0` before indexing `fieldsObjects`
- add a regression test that exercises a malformed `fo = -1` entry and verifies it is ignored rather than thrown