### PR TITLE
Fix array element opcode type handling

### DIFF
--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -1353,10 +1353,34 @@ spiperf.Begin();
 							interpretedThrow(pc - 1, new IndexOutOfRangeException());
 							break;
 						}
-						// The compiler can emit one opcode variant for several element types
-						// (e.g. ldelem.i8 for both long[] and ulong[]), so load based on the
-						// array's actual element type rather than the opcode variant.
-						stackBuffer[sp].LoadArrayElement( arr, index );
+						switch( b - 0x90 )
+						{
+						// The opcode determines the stack type.  The hard casts also accept CLR-compatible
+						// arrays (signedness variants like int[]/uint[], enum arrays as their underlying
+						// type), so they need no per-array-type handling.
+						case 0: stackBuffer[sp].LoadSByte( ((sbyte[])arr)[index] ); break; // ldelem.i1
+						case 1: stackBuffer[sp].LoadByte( ((byte[])arr)[index] ); break; // ldelem.u1
+						case 2: stackBuffer[sp].LoadShort( ((short[])arr)[index] ); break; // ldelem.i2
+						case 3: // ldelem.u2 (used for UInt16/Char element arrays; char[] does not cast to ushort[])
+							if( arr is char[] charArr )
+								stackBuffer[sp].LoadUshort( charArr[index] );
+							else
+								stackBuffer[sp].LoadUshort( ((ushort[])arr)[index] );
+							break;
+						case 4: stackBuffer[sp].LoadInt( ((int[])arr)[index] ); break; // ldelem.i4
+						case 5: stackBuffer[sp].LoadUint( ((uint[])arr)[index] ); break; // ldelem.u4
+						case 6: // ldelem.i8: the only variant without an unsigned counterpart, emitted for
+							// long[] and ulong[] alike.  A (ulong[]) cast also succeeds on a long[], so
+							// only here the element type must decide the signedness of the stack type.
+							if( Type.GetTypeCode( arr.GetType().GetElementType() ) == TypeCode.UInt64 )
+								stackBuffer[sp].LoadUlong( ((ulong[])arr)[index] );
+							else
+								stackBuffer[sp].LoadLong( ((long[])arr)[index] );
+							break;
+						case 7: stackBuffer[sp].LoadNint( ((nint[])arr)[index] ); break; // ldelem.i
+						case 8: stackBuffer[sp].LoadFloat( ((float[])arr)[index] ); break; // ldelem.r4
+						case 9: stackBuffer[sp].LoadDouble( ((double[])arr)[index] ); break; // ldelem.r8
+						}
 						break;
 					}
 					case 0x9a: // Ldelem_Ref
@@ -1424,10 +1448,35 @@ spiperf.Begin();
 							interpretedThrow(pc - 1, new IndexOutOfRangeException());
 							break;
 						}
-						// Same as ldelem: one opcode variant can cover several element types
-						// (e.g. stelem.ref for object[] and string[]), so store based on the
-						// array's actual element type rather than the opcode variant.
-						valSE.StoreToArray( asArr, index );
+						switch( b - 0x9b )
+						{
+						case 0: asArr.SetValue( (nint)valSE.l, index ); break; // stelem.i
+						case 1: asArr.SetValue( (byte)(SByte)valSE.i, index ); break; // stelem.i1
+						case 2: // stelem.i2 (used for Int16/UInt16/Char element arrays)
+							if( arrSE.o is ushort[] ushortArr )
+								ushortArr[index] = (ushort)valSE.u;
+							else if( arrSE.o is char[] charArr )
+								charArr[index] = (char)valSE.u;
+							else
+								asArr.SetValue( (short)valSE.i, index );
+							break;
+						case 3: // stelem.i4 (used for Int32/UInt32 element arrays)
+							if( arrSE.o is uint[] uintArr )
+								uintArr[index] = valSE.u;
+							else
+								asArr.SetValue( valSE.i, index );
+							break;
+						case 4: // stelem.i8 (used for Int64/UInt64 element arrays; SetValue can't
+							// put a boxed long into a ulong[], so store through the array cast)
+							if( Type.GetTypeCode( asArr.GetType().GetElementType() ) == TypeCode.UInt64 )
+								((ulong[])asArr)[index] = valSE.e;
+							else
+								((long[])asArr)[index] = valSE.l;
+							break;
+						case 5: ((float[])arrSE.AsObject())[index] = valSE.f; break; // stelem.r4
+						case 6: ((double[])arrSE.AsObject())[index] = valSE.d; break; // stelem.r8
+						case 7: ((object[])arrSE.AsObject())[index] = valSE.AsObject(); break; // stelem.ref
+						}
 						break;
 					}
 					case 0xa4: // stelem <typeTok>

--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -1342,30 +1342,96 @@ spiperf.Begin();
 					case 0x95: case 0x96: case 0x97: case 0x98: case 0x99:
 					{
 						int index = stackBuffer[sp--].i;
-						if (stackBuffer[sp].o == null)
+						object arrObj = stackBuffer[sp].o;
+						if (arrObj == null)
 						{
 							interpretedThrow(pc - 1, new NullReferenceException());
 							break;
 						}
-						if (index < 0 || index >= ((Array)stackBuffer[sp].o).Length)
+						Array arr = (Array)arrObj;
+						if (index < 0 || index >= arr.Length)
 						{
 							interpretedThrow(pc - 1, new IndexOutOfRangeException());
 							break;
 						}
 						switch( b - 0x90 )
 						{
-						// Does this way work universally?  Can we assume the compiler knows what it's doing?
-						// Previously it looked more like a.GetValue( index ).
-						case 0: stackBuffer[sp].LoadSByte( (sbyte)(((sbyte[])stackBuffer[sp].o)[index]) ); break; // ldelem.i1
-						case 1: stackBuffer[sp].LoadByte( (byte)(((byte[])stackBuffer[sp].o)[index]) ); break; // ldelem.u1
-						case 2: stackBuffer[sp].LoadShort( (short)(((short[])stackBuffer[sp].o)[index]) ); break; // ldelem.i2
-						case 3: stackBuffer[sp].LoadUshort( (ushort)(((ushort[])stackBuffer[sp].o)[index]) ); break; // ldelem.u2
-						case 4: stackBuffer[sp].LoadInt( (int)(((int[])stackBuffer[sp].o)[index]) ); break; // ldelem.i4
-						case 5: stackBuffer[sp].LoadUint( (uint)(((uint[])stackBuffer[sp].o)[index]) ); break; // ldelem.u4
-						case 6: stackBuffer[sp].LoadUlong( (ulong)(((ulong[])stackBuffer[sp].o)[index]) ); break; // ldelem.u8 / ldelem.i8
-						case 7: stackBuffer[sp].LoadNint( (nint)(((nint[])stackBuffer[sp].o)[index]) ); break; // ldelem.i
-						case 8: stackBuffer[sp].LoadFloat( (float)(((float[])stackBuffer[sp].o)[index]) ); break; // ldelem.r4
-						case 9: stackBuffer[sp].LoadDouble( (double)(((double[])stackBuffer[sp].o)[index]) ); break; // ldelem.r8
+						case 0:
+							if( arrObj is sbyte[] sbyteArr )
+								stackBuffer[sp].LoadSByte( sbyteArr[index] );
+							else if( arrObj is bool[] boolArr )
+								stackBuffer[sp].LoadSByte( boolArr[index] ? (sbyte)1 : (sbyte)0 );
+							else
+								stackBuffer[sp].LoadSByte( Convert.ToSByte( arr.GetValue(index) ) );
+							break; // ldelem.i1
+						case 1:
+							if( arrObj is byte[] byteArr )
+								stackBuffer[sp].LoadByte( byteArr[index] );
+							else if( arrObj is bool[] boolArr )
+								stackBuffer[sp].LoadByte( boolArr[index] ? (byte)1 : (byte)0 );
+							else
+								stackBuffer[sp].LoadByte( Convert.ToByte( arr.GetValue(index) ) );
+							break; // ldelem.u1
+						case 2:
+							if( arrObj is short[] shortArr )
+								stackBuffer[sp].LoadShort( shortArr[index] );
+							else if( arrObj is char[] charArr )
+								stackBuffer[sp].LoadShort( (short)charArr[index] );
+							else
+								stackBuffer[sp].LoadShort( Convert.ToInt16( arr.GetValue(index) ) );
+							break; // ldelem.i2
+						case 3:
+							if( arrObj is ushort[] ushortArr )
+								stackBuffer[sp].LoadUshort( ushortArr[index] );
+							else if( arrObj is char[] charArr )
+								stackBuffer[sp].LoadUshort( charArr[index] );
+							else
+								stackBuffer[sp].LoadUshort( Convert.ToUInt16( arr.GetValue(index) ) );
+							break; // ldelem.u2
+						case 4:
+							if( arrObj is int[] intArr )
+								stackBuffer[sp].LoadInt( intArr[index] );
+							else
+								stackBuffer[sp].LoadInt( Convert.ToInt32( arr.GetValue(index) ) );
+							break; // ldelem.i4
+						case 5:
+							if( arrObj is uint[] uintArr )
+								stackBuffer[sp].LoadUint( uintArr[index] );
+							else
+								stackBuffer[sp].LoadUint( Convert.ToUInt32( arr.GetValue(index) ) );
+							break; // ldelem.u4
+						case 6:
+							if( arrObj is long[] longArr )
+								stackBuffer[sp].LoadLong( longArr[index] );
+							else if( arrObj is ulong[] ulongArr )
+								stackBuffer[sp].LoadUlong( ulongArr[index] );
+							else
+							{
+								object value = arr.GetValue(index);
+								if( value is ulong ulongValue )
+									stackBuffer[sp].LoadUlong( ulongValue );
+								else
+									stackBuffer[sp].LoadLong( Convert.ToInt64( value ) );
+							}
+							break;
+						case 7:
+							if( arrObj is nint[] nintArr )
+								stackBuffer[sp].LoadNint( nintArr[index] );
+							else
+								stackBuffer[sp].LoadNint( (nint)Convert.ToInt64( arr.GetValue(index) ) );
+							break; // ldelem.i
+						case 8:
+							if( arrObj is float[] floatArr )
+								stackBuffer[sp].LoadFloat( floatArr[index] );
+							else
+								stackBuffer[sp].LoadFloat( Convert.ToSingle( arr.GetValue(index) ) );
+							break; // ldelem.r4
+						case 9:
+							if( arrObj is double[] doubleArr )
+								stackBuffer[sp].LoadDouble( doubleArr[index] );
+							else
+								stackBuffer[sp].LoadDouble( Convert.ToDouble( arr.GetValue(index) ) );
+							break; // ldelem.r8
 
 						}
 						break;
@@ -1385,7 +1451,10 @@ spiperf.Begin();
 							interpretedThrow(pc - 1, new IndexOutOfRangeException());
 							break;
 						}
-						stackBuffer[++sp].LoadObject( a.GetValue(index) );
+						if( arrSE.o is object[] objectArr )
+							stackBuffer[++sp].LoadObject( objectArr[index] );
+						else
+							stackBuffer[++sp].LoadObject( a.GetValue(index) );
 						break;
 					}
 					case 0xa3: // ldelem <typeTok>
@@ -1424,12 +1493,13 @@ spiperf.Begin();
 						StackElement valSE = stackBuffer[sp--];
 						int index = stackBuffer[sp--].i;
 						StackElement arrSE = stackBuffer[sp--];
-						if (arrSE.o == null)
+						object arrObj = arrSE.o;
+						if (arrObj == null)
 						{
 							interpretedThrow(pc - 1, new NullReferenceException());
 							break;
 						}
-						Array asArr = (Array)(arrSE.o);
+						Array asArr = (Array)arrObj;
 						if (index < 0 || index >= asArr.Length)
 						{
 							interpretedThrow(pc - 1, new IndexOutOfRangeException());
@@ -1437,26 +1507,67 @@ spiperf.Begin();
 						}
 						switch( b - 0x9b )
 						{
-						case 0: asArr.SetValue( (nint)valSE.l, index ); break; // stelem.i
-						case 1: asArr.SetValue( (byte)(SByte)valSE.i, index ); break; // stelem.i1
+						case 0:
+							if( arrObj is nint[] nintArr )
+								nintArr[index] = (nint)valSE.l;
+							else
+								asArr.SetValue( (nint)valSE.l, index );
+							break; // stelem.i
+						case 1:
+							if( arrObj is sbyte[] sbyteArr )
+								sbyteArr[index] = (sbyte)valSE.i;
+							else if( arrObj is byte[] byteArr )
+								byteArr[index] = (byte)valSE.u;
+							else if( arrObj is bool[] boolArr )
+								boolArr[index] = valSE.i != 0;
+							else
+								asArr.SetValue( (byte)(SByte)valSE.i, index );
+							break; // stelem.i1
 						case 2: // stelem.i2 (used for Int16/UInt16/Char element arrays)
-							if( arrSE.o is ushort[] ushortArr )
+							if( arrObj is short[] shortArr )
+								shortArr[index] = (short)valSE.i;
+							else if( arrObj is ushort[] ushortArr )
 								ushortArr[index] = (ushort)valSE.u;
-							else if( arrSE.o is char[] charArr )
+							else if( arrObj is char[] charArr )
 								charArr[index] = (char)valSE.u;
 							else
 								asArr.SetValue( (short)valSE.i, index );
 							break;
 						case 3: // stelem.i4 (used for Int32/UInt32 element arrays)
-							if( arrSE.o is uint[] uintArr )
+							if( arrObj is int[] intArr )
+								intArr[index] = valSE.i;
+							else if( arrObj is uint[] uintArr )
 								uintArr[index] = valSE.u;
 							else
 								asArr.SetValue( valSE.i, index );
 							break;
-						case 4: asArr.SetValue( valSE.l, index ); break; // stelem.i8
-						case 5: ((float[])arrSE.AsObject())[index] = valSE.f; break; // stelem.r4
-						case 6: ((double[])arrSE.AsObject())[index] = valSE.d; break; // stelem.r8
-						case 7: ((object[])arrSE.AsObject())[index] = valSE.AsObject(); break; // stelem.ref
+						case 4:
+							if( arrObj is long[] longArr )
+								longArr[index] = valSE.l;
+							else if( arrObj is ulong[] ulongArr )
+								ulongArr[index] = valSE.e;
+							else
+								asArr.SetValue( valSE.l, index );
+							break; // stelem.i8
+						case 5:
+							if( arrObj is float[] floatArr )
+								floatArr[index] = valSE.f;
+							else
+								asArr.SetValue( valSE.f, index );
+							break; // stelem.r4
+						case 6:
+							if( arrObj is double[] doubleArr )
+								doubleArr[index] = valSE.d;
+							else
+								asArr.SetValue( valSE.d, index );
+							break; // stelem.r8
+						case 7:
+							object value = valSE.AsObject();
+							if( arrObj is object[] objectArr )
+								objectArr[index] = value;
+							else
+								asArr.SetValue( value, index );
+							break; // stelem.ref
 						}
 						break;
 					}

--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -1342,98 +1342,21 @@ spiperf.Begin();
 					case 0x95: case 0x96: case 0x97: case 0x98: case 0x99:
 					{
 						int index = stackBuffer[sp--].i;
-						object arrObj = stackBuffer[sp].o;
-						if (arrObj == null)
+						if (stackBuffer[sp].o == null)
 						{
 							interpretedThrow(pc - 1, new NullReferenceException());
 							break;
 						}
-						Array arr = (Array)arrObj;
+						Array arr = (Array)stackBuffer[sp].o;
 						if (index < 0 || index >= arr.Length)
 						{
 							interpretedThrow(pc - 1, new IndexOutOfRangeException());
 							break;
 						}
-						switch( b - 0x90 )
-						{
-						case 0:
-							if( arrObj is sbyte[] sbyteArr )
-								stackBuffer[sp].LoadSByte( sbyteArr[index] );
-							else if( arrObj is bool[] boolArr )
-								stackBuffer[sp].LoadSByte( boolArr[index] ? (sbyte)1 : (sbyte)0 );
-							else
-								stackBuffer[sp].LoadSByte( Convert.ToSByte( arr.GetValue(index) ) );
-							break; // ldelem.i1
-						case 1:
-							if( arrObj is byte[] byteArr )
-								stackBuffer[sp].LoadByte( byteArr[index] );
-							else if( arrObj is bool[] boolArr )
-								stackBuffer[sp].LoadByte( boolArr[index] ? (byte)1 : (byte)0 );
-							else
-								stackBuffer[sp].LoadByte( Convert.ToByte( arr.GetValue(index) ) );
-							break; // ldelem.u1
-						case 2:
-							if( arrObj is short[] shortArr )
-								stackBuffer[sp].LoadShort( shortArr[index] );
-							else if( arrObj is char[] charArr )
-								stackBuffer[sp].LoadShort( (short)charArr[index] );
-							else
-								stackBuffer[sp].LoadShort( Convert.ToInt16( arr.GetValue(index) ) );
-							break; // ldelem.i2
-						case 3:
-							if( arrObj is ushort[] ushortArr )
-								stackBuffer[sp].LoadUshort( ushortArr[index] );
-							else if( arrObj is char[] charArr )
-								stackBuffer[sp].LoadUshort( charArr[index] );
-							else
-								stackBuffer[sp].LoadUshort( Convert.ToUInt16( arr.GetValue(index) ) );
-							break; // ldelem.u2
-						case 4:
-							if( arrObj is int[] intArr )
-								stackBuffer[sp].LoadInt( intArr[index] );
-							else
-								stackBuffer[sp].LoadInt( Convert.ToInt32( arr.GetValue(index) ) );
-							break; // ldelem.i4
-						case 5:
-							if( arrObj is uint[] uintArr )
-								stackBuffer[sp].LoadUint( uintArr[index] );
-							else
-								stackBuffer[sp].LoadUint( Convert.ToUInt32( arr.GetValue(index) ) );
-							break; // ldelem.u4
-						case 6:
-							if( arrObj is long[] longArr )
-								stackBuffer[sp].LoadLong( longArr[index] );
-							else if( arrObj is ulong[] ulongArr )
-								stackBuffer[sp].LoadUlong( ulongArr[index] );
-							else
-							{
-								object value = arr.GetValue(index);
-								if( value is ulong ulongValue )
-									stackBuffer[sp].LoadUlong( ulongValue );
-								else
-									stackBuffer[sp].LoadLong( Convert.ToInt64( value ) );
-							}
-							break;
-						case 7:
-							if( arrObj is nint[] nintArr )
-								stackBuffer[sp].LoadNint( nintArr[index] );
-							else
-								stackBuffer[sp].LoadNint( (nint)Convert.ToInt64( arr.GetValue(index) ) );
-							break; // ldelem.i
-						case 8:
-							if( arrObj is float[] floatArr )
-								stackBuffer[sp].LoadFloat( floatArr[index] );
-							else
-								stackBuffer[sp].LoadFloat( Convert.ToSingle( arr.GetValue(index) ) );
-							break; // ldelem.r4
-						case 9:
-							if( arrObj is double[] doubleArr )
-								stackBuffer[sp].LoadDouble( doubleArr[index] );
-							else
-								stackBuffer[sp].LoadDouble( Convert.ToDouble( arr.GetValue(index) ) );
-							break; // ldelem.r8
-
-						}
+						// The compiler can emit one opcode variant for several element types
+						// (e.g. ldelem.i8 for both long[] and ulong[]), so load based on the
+						// array's actual element type rather than the opcode variant.
+						stackBuffer[sp].LoadArrayElement( arr, index );
 						break;
 					}
 					case 0x9a: // Ldelem_Ref
@@ -1451,10 +1374,7 @@ spiperf.Begin();
 							interpretedThrow(pc - 1, new IndexOutOfRangeException());
 							break;
 						}
-						if( arrSE.o is object[] objectArr )
-							stackBuffer[++sp].LoadObject( objectArr[index] );
-						else
-							stackBuffer[++sp].LoadObject( a.GetValue(index) );
+						stackBuffer[++sp].LoadObject( a.GetValue(index) );
 						break;
 					}
 					case 0xa3: // ldelem <typeTok>
@@ -1493,82 +1413,21 @@ spiperf.Begin();
 						StackElement valSE = stackBuffer[sp--];
 						int index = stackBuffer[sp--].i;
 						StackElement arrSE = stackBuffer[sp--];
-						object arrObj = arrSE.o;
-						if (arrObj == null)
+						if (arrSE.o == null)
 						{
 							interpretedThrow(pc - 1, new NullReferenceException());
 							break;
 						}
-						Array asArr = (Array)arrObj;
+						Array asArr = (Array)(arrSE.o);
 						if (index < 0 || index >= asArr.Length)
 						{
 							interpretedThrow(pc - 1, new IndexOutOfRangeException());
 							break;
 						}
-						switch( b - 0x9b )
-						{
-						case 0:
-							if( arrObj is nint[] nintArr )
-								nintArr[index] = (nint)valSE.l;
-							else
-								asArr.SetValue( (nint)valSE.l, index );
-							break; // stelem.i
-						case 1:
-							if( arrObj is sbyte[] sbyteArr )
-								sbyteArr[index] = (sbyte)valSE.i;
-							else if( arrObj is byte[] byteArr )
-								byteArr[index] = (byte)valSE.u;
-							else if( arrObj is bool[] boolArr )
-								boolArr[index] = valSE.i != 0;
-							else
-								asArr.SetValue( (byte)(SByte)valSE.i, index );
-							break; // stelem.i1
-						case 2: // stelem.i2 (used for Int16/UInt16/Char element arrays)
-							if( arrObj is short[] shortArr )
-								shortArr[index] = (short)valSE.i;
-							else if( arrObj is ushort[] ushortArr )
-								ushortArr[index] = (ushort)valSE.u;
-							else if( arrObj is char[] charArr )
-								charArr[index] = (char)valSE.u;
-							else
-								asArr.SetValue( (short)valSE.i, index );
-							break;
-						case 3: // stelem.i4 (used for Int32/UInt32 element arrays)
-							if( arrObj is int[] intArr )
-								intArr[index] = valSE.i;
-							else if( arrObj is uint[] uintArr )
-								uintArr[index] = valSE.u;
-							else
-								asArr.SetValue( valSE.i, index );
-							break;
-						case 4:
-							if( arrObj is long[] longArr )
-								longArr[index] = valSE.l;
-							else if( arrObj is ulong[] ulongArr )
-								ulongArr[index] = valSE.e;
-							else
-								asArr.SetValue( valSE.l, index );
-							break; // stelem.i8
-						case 5:
-							if( arrObj is float[] floatArr )
-								floatArr[index] = valSE.f;
-							else
-								asArr.SetValue( valSE.f, index );
-							break; // stelem.r4
-						case 6:
-							if( arrObj is double[] doubleArr )
-								doubleArr[index] = valSE.d;
-							else
-								asArr.SetValue( valSE.d, index );
-							break; // stelem.r8
-						case 7:
-							object value = valSE.AsObject();
-							if( arrObj is object[] objectArr )
-								objectArr[index] = value;
-							else
-								asArr.SetValue( value, index );
-							break; // stelem.ref
-						}
+						// Same as ldelem: one opcode variant can cover several element types
+						// (e.g. stelem.ref for object[] and string[]), so store based on the
+						// array's actual element type rather than the opcode variant.
+						valSE.StoreToArray( asArr, index );
 						break;
 					}
 					case 0xa4: // stelem <typeTok>

--- a/Packages/com.cnlohr.cilbox/CilboxUtil.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxUtil.cs
@@ -120,58 +120,6 @@ namespace Cilbox
 		public StackElement LoadUlongType( ulong e, StackType t ) { this.e = e; type = t; return this; }
 		public StackElement LoadLongType( long l, StackType t ) { this.l = l; type = t; return this; }
 
-		// ldelem/stelem: the compiler can emit the same opcode for several compatible element
-		// types (e.g. stelem.i2 for short[]/ushort[]/char[], stelem.i8 for long[]/ulong[]), so
-		// dispatch on the array's actual element type instead of the opcode variant.  TypeCode
-		// is used because isinst cannot tell apart arrays of same-size primitives (int[]/uint[],
-		// enum arrays, etc).  Enum arrays land on their underlying type's TypeCode, which matches
-		// how enums are represented on the stack.
-		public void LoadArrayElement( Array arr, int index )
-		{
-			switch( Type.GetTypeCode( arr.GetType().GetElementType() ) )
-			{
-			case TypeCode.Boolean: LoadLongType( ((bool[])arr)[index] ? 1 : 0, StackType.Boolean ); break;
-			case TypeCode.SByte:   LoadSByte( ((sbyte[])arr)[index] ); break;
-			case TypeCode.Byte:    LoadByte( ((byte[])arr)[index] ); break;
-			case TypeCode.Int16:   LoadShort( ((short[])arr)[index] ); break;
-			case TypeCode.UInt16:  LoadUshort( ((ushort[])arr)[index] ); break;
-			case TypeCode.Char:    LoadUshort( ((char[])arr)[index] ); break;
-			case TypeCode.Int32:   LoadInt( ((int[])arr)[index] ); break;
-			case TypeCode.UInt32:  LoadUint( ((uint[])arr)[index] ); break;
-			case TypeCode.Int64:   LoadLong( ((long[])arr)[index] ); break;
-			case TypeCode.UInt64:  LoadUlong( ((ulong[])arr)[index] ); break;
-			case TypeCode.Single:  LoadFloat( ((float[])arr)[index] ); break;
-			case TypeCode.Double:  LoadDouble( ((double[])arr)[index] ); break;
-			default:
-				if( arr is nint[] nintArr ) LoadNint( nintArr[index] );
-				else Load( arr.GetValue( index ) );
-				break;
-			}
-		}
-
-		public void StoreToArray( Array arr, int index )
-		{
-			switch( Type.GetTypeCode( arr.GetType().GetElementType() ) )
-			{
-			case TypeCode.Boolean: ((bool[])arr)[index] = l != 0; break;
-			case TypeCode.SByte:   ((sbyte[])arr)[index] = (sbyte)i; break;
-			case TypeCode.Byte:    ((byte[])arr)[index] = (byte)u; break;
-			case TypeCode.Int16:   ((short[])arr)[index] = (short)i; break;
-			case TypeCode.UInt16:  ((ushort[])arr)[index] = (ushort)u; break;
-			case TypeCode.Char:    ((char[])arr)[index] = (char)u; break;
-			case TypeCode.Int32:   ((int[])arr)[index] = i; break;
-			case TypeCode.UInt32:  ((uint[])arr)[index] = u; break;
-			case TypeCode.Int64:   ((long[])arr)[index] = l; break;
-			case TypeCode.UInt64:  ((ulong[])arr)[index] = e; break;
-			case TypeCode.Single:  ((float[])arr)[index] = f; break;
-			case TypeCode.Double:  ((double[])arr)[index] = d; break;
-			default:
-				if( arr is nint[] nintArr ) nintArr[index] = (nint)l;
-				else arr.SetValue( AsObject(), index );
-				break;
-			}
-		}
-
 		public Type GetInnerType()
 		{
 			if( type == StackType.Object )

--- a/Packages/com.cnlohr.cilbox/CilboxUtil.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxUtil.cs
@@ -120,6 +120,58 @@ namespace Cilbox
 		public StackElement LoadUlongType( ulong e, StackType t ) { this.e = e; type = t; return this; }
 		public StackElement LoadLongType( long l, StackType t ) { this.l = l; type = t; return this; }
 
+		// ldelem/stelem: the compiler can emit the same opcode for several compatible element
+		// types (e.g. stelem.i2 for short[]/ushort[]/char[], stelem.i8 for long[]/ulong[]), so
+		// dispatch on the array's actual element type instead of the opcode variant.  TypeCode
+		// is used because isinst cannot tell apart arrays of same-size primitives (int[]/uint[],
+		// enum arrays, etc).  Enum arrays land on their underlying type's TypeCode, which matches
+		// how enums are represented on the stack.
+		public void LoadArrayElement( Array arr, int index )
+		{
+			switch( Type.GetTypeCode( arr.GetType().GetElementType() ) )
+			{
+			case TypeCode.Boolean: LoadLongType( ((bool[])arr)[index] ? 1 : 0, StackType.Boolean ); break;
+			case TypeCode.SByte:   LoadSByte( ((sbyte[])arr)[index] ); break;
+			case TypeCode.Byte:    LoadByte( ((byte[])arr)[index] ); break;
+			case TypeCode.Int16:   LoadShort( ((short[])arr)[index] ); break;
+			case TypeCode.UInt16:  LoadUshort( ((ushort[])arr)[index] ); break;
+			case TypeCode.Char:    LoadUshort( ((char[])arr)[index] ); break;
+			case TypeCode.Int32:   LoadInt( ((int[])arr)[index] ); break;
+			case TypeCode.UInt32:  LoadUint( ((uint[])arr)[index] ); break;
+			case TypeCode.Int64:   LoadLong( ((long[])arr)[index] ); break;
+			case TypeCode.UInt64:  LoadUlong( ((ulong[])arr)[index] ); break;
+			case TypeCode.Single:  LoadFloat( ((float[])arr)[index] ); break;
+			case TypeCode.Double:  LoadDouble( ((double[])arr)[index] ); break;
+			default:
+				if( arr is nint[] nintArr ) LoadNint( nintArr[index] );
+				else Load( arr.GetValue( index ) );
+				break;
+			}
+		}
+
+		public void StoreToArray( Array arr, int index )
+		{
+			switch( Type.GetTypeCode( arr.GetType().GetElementType() ) )
+			{
+			case TypeCode.Boolean: ((bool[])arr)[index] = l != 0; break;
+			case TypeCode.SByte:   ((sbyte[])arr)[index] = (sbyte)i; break;
+			case TypeCode.Byte:    ((byte[])arr)[index] = (byte)u; break;
+			case TypeCode.Int16:   ((short[])arr)[index] = (short)i; break;
+			case TypeCode.UInt16:  ((ushort[])arr)[index] = (ushort)u; break;
+			case TypeCode.Char:    ((char[])arr)[index] = (char)u; break;
+			case TypeCode.Int32:   ((int[])arr)[index] = i; break;
+			case TypeCode.UInt32:  ((uint[])arr)[index] = u; break;
+			case TypeCode.Int64:   ((long[])arr)[index] = l; break;
+			case TypeCode.UInt64:  ((ulong[])arr)[index] = e; break;
+			case TypeCode.Single:  ((float[])arr)[index] = f; break;
+			case TypeCode.Double:  ((double[])arr)[index] = d; break;
+			default:
+				if( arr is nint[] nintArr ) nintArr[index] = (nint)l;
+				else arr.SetValue( AsObject(), index );
+				break;
+			}
+		}
+
 		public Type GetInnerType()
 		{
 			if( type == StackType.Object )

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -750,6 +750,21 @@ namespace TestCilbox
 			Validator.Validate("Object Array Element Access With Data 1", "64");
 			Validator.Validate("Object Array Element Access With Data 2", "delta");
 
+			Validator.Validate("Long Array With Data Length", "3");
+			Validator.Validate("Long Array With Data 0", "-1");
+			Validator.Validate("Long Array With Data 1", "9876543210");
+			Validator.Validate("Long Array With Data 2", long.MinValue.ToString());
+
+			Validator.Validate("Char Array With Data Length", "3");
+			Validator.Validate("Char Array With Data 0", "a");
+			Validator.Validate("Char Array With Data 1", "4660");
+			Validator.Validate("Char Array With Data 2", "Z");
+
+			Validator.Validate("String Array Assigned Length", "3");
+			Validator.Validate("String Array Assigned 0", "red");
+			Validator.Validate("String Array Assigned 1", "green");
+			Validator.Validate("String Array Assigned 2", "blue");
+
 			// Boxing enums
 			Validator.Validate("Boxed MyEnum", "Value2");
 			Validator.Validate("Boxed TestEnum", "SecondValue");

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -53,6 +53,7 @@ namespace TestCilbox
 			"System.TimeSpan",
 			"System.UInt16",
 			"System.UInt32",
+			"System.UInt64",
 			"System.ValueTuple",
 			"System.Void",
 			"TestCilbox.Outer+Middle+Inner",
@@ -754,6 +755,11 @@ namespace TestCilbox
 			Validator.Validate("Long Array With Data 0", "-1");
 			Validator.Validate("Long Array With Data 1", "9876543210");
 			Validator.Validate("Long Array With Data 2", long.MinValue.ToString());
+			Validator.Validate("Long Array Signed Compare", "True");
+			Validator.Validate("Long Array Boxed", long.MinValue.ToString());
+
+			Validator.Validate("Ulong Array Assigned 0", ulong.MaxValue.ToString());
+			Validator.Validate("Ulong Array Assigned 1", "42");
 
 			Validator.Validate("Char Array With Data Length", "3");
 			Validator.Validate("Char Array With Data 0", "a");

--- a/TestCilbox/TestCilboxable.cs
+++ b/TestCilbox/TestCilboxable.cs
@@ -547,6 +547,17 @@ namespace TestCilbox
 			Validator.Set("Long Array With Data 0", longWithData[0].ToString() );
 			Validator.Set("Long Array With Data 1", longWithData[1].ToString() );
 			Validator.Set("Long Array With Data 2", longWithData[2].ToString() );
+			// Forces ldelem.i8 + signed comparison; fails if elements are loaded as unsigned.
+			Validator.Set("Long Array Signed Compare", (longWithData[0] < longWithData[1]).ToString() );
+			// Forces ldelem.i8 + box; boxing uses the stack type, so this fails if the
+			// element was loaded with an unsigned stack type.
+			Validator.Set("Long Array Boxed", ((object)longWithData[2]).ToString() );
+
+			ulong[] ulongAssigned = new ulong[2];
+			ulongAssigned[0] = ulong.MaxValue;
+			ulongAssigned[1] = 42UL;
+			Validator.Set("Ulong Array Assigned 0", ulongAssigned[0].ToString() );
+			Validator.Set("Ulong Array Assigned 1", ulongAssigned[1].ToString() );
 
 			char[] charWithData = new char[3];
 			charWithData[0] = 'a';

--- a/TestCilbox/TestCilboxable.cs
+++ b/TestCilbox/TestCilboxable.cs
@@ -542,6 +542,30 @@ namespace TestCilbox
 			Validator.Set("Object Array Element Access With Data 1", ObjectArrayElem(objectWithData, 1).ToString());
 			Validator.Set("Object Array Element Access With Data 2", ObjectArrayElem(objectWithData, 2).ToString());
 
+			long[] longWithData = new long[] { -1L, 9876543210L, long.MinValue };
+			Validator.Set("Long Array With Data Length", longWithData.Length.ToString() );
+			Validator.Set("Long Array With Data 0", longWithData[0].ToString() );
+			Validator.Set("Long Array With Data 1", longWithData[1].ToString() );
+			Validator.Set("Long Array With Data 2", longWithData[2].ToString() );
+
+			char[] charWithData = new char[3];
+			charWithData[0] = 'a';
+			charWithData[1] = '\u1234';
+			charWithData[2] = 'Z';
+			Validator.Set("Char Array With Data Length", charWithData.Length.ToString() );
+			Validator.Set("Char Array With Data 0", charWithData[0].ToString() );
+			Validator.Set("Char Array With Data 1", ((int)charWithData[1]).ToString() );
+			Validator.Set("Char Array With Data 2", charWithData[2].ToString() );
+
+			string[] stringAssigned = new string[3];
+			stringAssigned[0] = "red";
+			stringAssigned[1] = "green";
+			stringAssigned[2] = "blue";
+			Validator.Set("String Array Assigned Length", stringAssigned.Length.ToString() );
+			Validator.Set("String Array Assigned 0", stringAssigned[0] );
+			Validator.Set("String Array Assigned 1", stringAssigned[1] );
+			Validator.Set("String Array Assigned 2", stringAssigned[2] );
+
 			object boxedMyEnum = MyEnum.Value2;
 			MyEnum castMyEnum = (MyEnum)boxedMyEnum;
 			Validator.Set("Boxed MyEnum", castMyEnum.ToString() );


### PR DESCRIPTION
This fixes a few array opcode cases where the interpreter assumed one exact CLR array type even though normal C# can emit the same opcode for related element types.

Changes:
- load `ldelem.*` values through the actual array element value instead of fixed casts such as `ulong[]`
- store `stelem.ref` through `Array.SetValue`, so reference arrays such as `string[]` work
- add coverage for `long[]`, `char[]`, and `string[]`