### PR TITLE
Key exported methods by full signature

### DIFF
--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -74,6 +74,8 @@ namespace Cilbox
 			methodName = name;
 			parentClass = cclass;
 			Dictionary<String, Serializee> methodProps = payload.AsMap();
+			if( methodProps.TryGetValue( "name", out Serializee methodNameSer ) )
+				methodName = methodNameSer.AsString();
 
 			Serializee [] vl = methodProps["locals"].AsArray();
 			methodLocals = new String[vl.Length];
@@ -1928,7 +1930,7 @@ spiperf.End();
 			{
 				methods[id] = new CilboxMethod();
 				methods[id].Load( this, k.Key, k.Value );
-				methodNameToIndex[(String)k.Key] = id;
+				methodNameToIndex[methods[id].methodName] = id;
 				methodFullSignatureToIndex[methods[id].fullSignature] = id;
 				id++;
 			}
@@ -2921,9 +2923,10 @@ spiperf.End();
 							MethodProps["isVoid"] = new Serializee( (m is MethodInfo)?(((MethodInfo)m).ReturnType == typeof(void) ? "1" : "0" ): (isCtor ? "1" : "0") );
 							MethodProps["isCtor"] = new Serializee( isCtor ? "1" : "0" );
 							MethodProps["isStatic"] = new Serializee( m.IsStatic ? "1" : "0" );
+							MethodProps["name"] = new Serializee( methodName );
 							MethodProps["fullSignature"] = new Serializee( m.ToString() );
 
-							methods[methodName] = new Serializee( MethodProps );
+							methods[m.ToString()] = new Serializee( MethodProps );
 							perfMethod.End();
 						}
 					}

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -428,6 +428,8 @@ namespace TestCilbox
 
 				Validator.Validate( "recursive function", "511" );
 				Validator.Validate( "string concatenation", "it works" );
+				Validator.Validate( "OverloadEcho int", "int:42" );
+				Validator.Validate( "OverloadEcho string", "string:forty-two" );
 				Validator.Validate( "MathF.Sin", "-0.058374193" );
 
 				// Make sure CI can fail.

--- a/TestCilbox/TestCilboxable.cs
+++ b/TestCilbox/TestCilboxable.cs
@@ -69,6 +69,16 @@ namespace TestCilbox
 			RecursiveTest( i-1 );
 		}
 
+		public string OverloadEcho(int value)
+		{
+			return "int:" + value;
+		}
+
+		public string OverloadEcho(string value)
+		{
+			return "string:" + value;
+		}
+
 		public void Start()
 		{
 			Debug.Log( "🔵 TestCilboxBehaviour.Start()" );
@@ -92,6 +102,8 @@ namespace TestCilbox
 			RecursiveTest(8);
 			Validator.Set( "recursive function", recursive_test_counter.ToString() );
 			Validator.Set( "string concatenation", "it" + " " + "works" );
+			Validator.Set( "OverloadEcho int", OverloadEcho(42) );
+			Validator.Set( "OverloadEcho string", OverloadEcho("forty-two") );
 			Validator.Set( "MathF.Sin", MathF.Sin(3.2f).ToString() );
 
 			using (DisposeTester dt = new DisposeTester())


### PR DESCRIPTION
The build export currently stores interpreted methods by method name, so overloads overwrite each other in the serialized class method map. The runtime already resolves interpreted calls by `fullSignature`, so this changes the exported key to match that lookup path.

Changes:
- store exported class methods by `MethodBase.ToString()` / full signature
- preserve the original method name in the method payload for entrypoint lookup and diagnostics
- make `methodNameToIndex` use the loaded method name rather than the serialized map key
- add a regression test for two overloads with the same name