### PR TITLE
Use declaring class for interpreted static fields

### DIFF
--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -1178,7 +1178,8 @@ spiperf.Begin();
 						}
 						else
 						{
-							stackBuffer[++sp].Load( parentClass.staticFields[ldsm.fieldIndex] );
+							CilboxClass declaringClass = ldsm.interpretiveFieldClass >= 0 ? box.classesList[ldsm.interpretiveFieldClass] : parentClass;
+							stackBuffer[++sp].Load( declaringClass.staticFields[ldsm.fieldIndex] );
 						}
 						break;
 					}
@@ -1196,7 +1197,8 @@ spiperf.Begin();
 						}
 						else
 						{
-							stackBuffer[++sp] = StackElement.CreateAddressReference( (Array)(parentClass.staticFields), (uint)ldsam.fieldIndex );
+							CilboxClass declaringClass = ldsam.interpretiveFieldClass >= 0 ? box.classesList[ldsam.interpretiveFieldClass] : parentClass;
+							stackBuffer[++sp] = StackElement.CreateAddressReference( (Array)(declaringClass.staticFields), (uint)ldsam.fieldIndex );
 						}
 						break;
 					}
@@ -1215,7 +1217,8 @@ spiperf.Begin();
 						}
 						else
 						{
-							parentClass.staticFields[stsm.fieldIndex] = obj;
+							CilboxClass declaringClass = stsm.interpretiveFieldClass >= 0 ? box.classesList[stsm.interpretiveFieldClass] : parentClass;
+							declaringClass.staticFields[stsm.fieldIndex] = obj;
 						}
 						break;
 					}
@@ -1994,6 +1997,7 @@ spiperf.End();
 		public MetaTokenType type;
 		public bool isValid;
 		public int fieldIndex; // Only used for fields of cilbox objects.
+		public int interpretiveFieldClass = -1;
 		public bool isFieldWhiteListed = false;
 		public FieldInfo nativeField; // For whitelisted fields on non-cilbox objects.
 
@@ -2181,6 +2185,8 @@ spiperf.End();
 					if( st.ContainsKey("index") )
 					{
 						t.fieldIndex = Convert.ToInt32(st["index"].AsString());
+						if( classes.TryGetValue( t.declaringTypeName, out int fieldClassId ) )
+							t.interpretiveFieldClass = fieldClassId;
 					}
 					else
 					{

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -728,6 +728,7 @@ namespace TestCilbox
 			Validator.Validate("WriteFloat_2", "99");
 			Validator.Validate("NativeStaticFloat ref written", "99");
 			Validator.Validate("ReadInt_2", "1114");
+			Validator.Validate("Cross Class Static Field", "321");
 
 			Validator.Validate("NativeOutVec3", "(12, 8, 0)");
 			Validator.Validate("CilOutVec3", "(1, 2, 3)");

--- a/TestCilbox/TestCilboxable.cs
+++ b/TestCilbox/TestCilboxable.cs
@@ -524,6 +524,8 @@ namespace TestCilbox
 			WriteFloat(ref TestUtil.StaticFloat, 99.0f);
 			Validator.Set("NativeStaticFloat ref written", TestUtil.StaticFloat.ToString());
 			ReadInt(ref iprivatestatic);
+			TestCilboxBehaviour2.sharedValue = 321;
+			Validator.Set("Cross Class Static Field", TestCilboxBehaviour2.sharedValue.ToString());
 
 			TestUtil.GetOutVec3(out Vector3 outVec);
 			Validator.Set("NativeOutVec3", outVec.ToString() );
@@ -793,6 +795,7 @@ namespace TestCilbox
 	[Cilboxable]
 	public class TestCilboxBehaviour2 : MonoBehaviour
 	{
+		public static int sharedValue = 123;
 		public int pubsettee = 35254;
 		public void Behaviour2Test()
 		{


### PR DESCRIPTION
Interpreted static field opcodes currently read and write `parentClass.staticFields`, which is the class containing the currently executing method. For a normal cross-class static field access, the token's declaring class can be different from `parentClass`, so the wrong static field slot is used.

Changes:
- cache the declaring interpreted class id on field metadata
- use the declaring class for `ldsfld`, `ldsflda`, and `stsfld`
- keep the old `parentClass` behavior as a fallback when no declaring interpreted class is known
- add coverage for writing a static field on a different Cilboxable class