### PR TITLE
Route native invocation exceptions to interpreted handlers

### DIFF
--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -484,7 +484,15 @@ spiperf.Begin();
 								ConstructorInfo ctor = (ConstructorInfo)st;
 								if( isNewObj )
 								{
-									iko = ctor.Invoke( callpar );
+									try
+									{
+										iko = ctor.Invoke( callpar );
+									}
+									catch( TargetInvocationException e )
+									{
+										interpretedThrow(pc - 1, e.InnerException ?? e);
+										break;
+									}
 									isVoid = false; // newobj always pushes a reference/value.
 								}
 								else
@@ -544,7 +552,15 @@ spiperf.Begin();
 									break;
 								}
 
-								iko = st.Invoke( callthis, callpar );
+								try
+								{
+									iko = st.Invoke( callthis, callpar );
+								}
+								catch( TargetInvocationException e )
+								{
+									interpretedThrow(pc - 1, e.InnerException ?? e);
+									break;
+								}
 								if( seorig.type == StackType.Address  && callthis is not BoxedCilboxEnum ) // enums are immutable
 								{
 									seorig.DereferenceLoadAddress( callthis );
@@ -556,7 +572,15 @@ spiperf.Begin();
 							}
 							else
 							{
-								iko = st.Invoke( null, callpar );
+								try
+								{
+									iko = st.Invoke( null, callpar );
+								}
+								catch( TargetInvocationException e )
+								{
+									interpretedThrow(pc - 1, e.InnerException ?? e);
+									break;
+								}
 							}
 
 							// Possibly copy back any references.
@@ -1690,7 +1714,7 @@ spiperf.End();
 				exceptionRegister = new StackElement() { type = StackType.Object, o = thrownObj };
 				if (!hasExceptionClauses)
 				{
-					throw new CilboxUnhandledInterpretedException("Exception thrown with no handlers: " + thrownObj.ToString(), thrownObj, parentClass.className, methodName, currentInstruction);
+					throw new CilboxUnhandledInterpretedException("Exception thrown with no handlers: " + (thrownObj?.ToString() ?? "(null)"), thrownObj, parentClass.className, methodName, currentInstruction);
 				}
 
 				CilboxExceptionHandlingClause found = null;
@@ -1745,7 +1769,7 @@ spiperf.End();
 
 				if (found == null)
 				{
-					throw new CilboxUnhandledInterpretedException("No handlers matched exception: " + thrownObj.ToString(), thrownObj, parentClass.className, methodName, currentInstruction);
+					throw new CilboxUnhandledInterpretedException("No handlers matched exception: " + (thrownObj?.ToString() ?? "(null)"), thrownObj, parentClass.className, methodName, currentInstruction);
 				}
 
 				leaveRegionEnqueueFinallys(currentInstruction, found.HandlerOffset, true);

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -504,6 +504,7 @@ namespace TestCilbox
 
 			Validator.Validate("NegativeIndexAccess", "caught");
 			Validator.Validate("PositiveIndexAccess", "caught");
+			Validator.Validate("NativeParseException", "caught");
 
 			Validator.Validate("StfldNullRef", "caught");
 			Validator.Validate("LdfldaNullRef", "caught");

--- a/TestCilbox/TestCilboxable.cs
+++ b/TestCilbox/TestCilboxable.cs
@@ -235,6 +235,17 @@ namespace TestCilbox
 				Validator.Set("PositiveIndexAccess", "caught");
 			}
 
+			try
+			{
+				Validator.Set("NativeParseException", "try");
+				int.Parse("not an int");
+				Validator.Set("NativeParseException", "didn't throw");
+			}
+			catch (Exception)
+			{
+				Validator.Set("NativeParseException", "caught");
+			}
+
 			// stfld on null
 			try
 			{


### PR DESCRIPTION
When a native method invoked through reflection throws, `MethodBase.Invoke` wraps it in `TargetInvocationException`. Previously that escaped the interpreted exception path and disabled the box even when the Cilboxable code had a matching `try/catch`.

Changes:
- unwrap `TargetInvocationException` from native constructor, instance method, and static method calls
- pass the underlying exception to the interpreted exception handler
- make unhandled interpreted exception messages tolerate a null thrown object
- add coverage for catching an exception thrown by a native method (`int.Parse`)