### PR TITLE
Nullable opcode

### DIFF
--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -503,6 +503,7 @@ spiperf.Begin();
 							}
 							object callthis = null;
 							Type[] paTypes = dt.nativeParameterTypes;
+							Type[] nullablePaTypes = dt.nativeParameterNullableUnderlyingTypes;
 							int numFields = paTypes.Length;
 							object [] callpar = new object[numFields];
 							StackElement [] callpar_se = new StackElement[numFields];
@@ -513,7 +514,8 @@ spiperf.Begin();
 								StackElement se = stackBuffer[sp--];
 								callpar_se[numFields-ik-1] = se;
 								object o = se.AsObject(box);
-								Type t = paTypes[numFields-ik-1];
+								int parameterIndex = numFields-ik-1;
+								Type t = paTypes[parameterIndex];
 
 								if( t.IsByRef )
 								{
@@ -533,10 +535,10 @@ spiperf.Begin();
 									if( o != null && t.IsValueType && o.GetType() != t )
 									{
 										//o = Convert.ChangeType( o, t );
-										o = se.CoerceToObject( t );
+										o = se.CoerceToObject( t, nullablePaTypes?[parameterIndex] );
 									}
 								}
-								callpar[numFields-ik-1] = o;
+								callpar[parameterIndex] = o;
 							}
 							if( st.IsConstructor )
 							{
@@ -1127,7 +1129,7 @@ spiperf.Begin();
 							break;
 						}
 
-						ldfldMeta.nativeField.SetValue( opths, se.CoerceToObject( ldfldMeta.nativeType ) );
+						ldfldMeta.nativeField.SetValue( opths, se.CoerceToObject( ldfldMeta.nativeType, ldfldMeta.nativeTypeNullableUnderlyingType ) );
 						break;
 					}
 					case 0x46: case 0x47: case 0x48: case 0x49: case 0x4a: // ldind
@@ -1281,7 +1283,9 @@ spiperf.Begin();
 						}
 						if( stsm.isFieldWhiteListed && stsm.nativeField != null )
 						{
-							stsm.nativeField.SetValue( null, obj );
+							StackElement se = new StackElement();
+							se.Load( obj );
+							stsm.nativeField.SetValue( null, se.CoerceToObject( stsm.nativeType, stsm.nativeTypeNullableUnderlyingType ) );
 						}
 						else
 						{
@@ -1296,7 +1300,7 @@ spiperf.Begin();
 						StackElement value = stackBuffer[sp--];
 						StackElement addr = stackBuffer[sp--];
 						object obj = ( stobjMeta.nativeType != null && value.type < StackType.Object ) ?
-							value.CoerceToObject( stobjMeta.nativeType ) :
+							value.CoerceToObject( stobjMeta.nativeType, stobjMeta.nativeTypeNullableUnderlyingType ) :
 							value.AsObject( box );
 
 						if( addr.type == StackType.Address )
@@ -2070,6 +2074,7 @@ spiperf.End();
 		public bool fieldIsStatic;
 
 		public Type nativeType; // Used for types.
+		public Type nativeTypeNullableUnderlyingType;
 		public bool nativeTypeIsStackType;
 		public bool nativeTypeIsCilboxProxy;
 		public StackType nativeTypeStackType;
@@ -2080,6 +2085,7 @@ spiperf.End();
 		public bool isNative;
 		public MethodBase nativeMethod;
 		public Type[] nativeParameterTypes;
+		public Type[] nativeParameterNullableUnderlyingTypes;
 		public bool nativeIsVoid;
 		public bool nativeIsSupportedNullableMethod;
 		public int interpretiveMethod; // If nativeToken is 0, then it's a interpreted call.
@@ -2285,6 +2291,7 @@ spiperf.End();
 						t.isFieldWhiteListed = true;
 						t.fieldIsStatic = f.IsStatic;
 						t.nativeType = f.FieldType;
+						t.nativeTypeNullableUnderlyingType = Nullable.GetUnderlyingType(t.nativeType);
 						t.nativeField = f;
 						t.isValid = true;
 
@@ -2312,6 +2319,7 @@ spiperf.End();
 				{
 					Serializee typ = st["dt"];
 					t.nativeType = usage.GetNativeTypeFromSerializee( typ );
+					t.nativeTypeNullableUnderlyingType = t.nativeType == null ? null : Nullable.GetUnderlyingType(t.nativeType);
 					StackType seType = StackElement.StackTypeFromType( t.nativeType );
 					if( seType < StackType.Object )
 					{
@@ -2426,11 +2434,14 @@ spiperf.End();
 							t.isValid = true;
 							ParameterInfo[] mp = m.GetParameters();
 							Type[] mpt = new Type[mp.Length];
+							Type[] nullableUnderlyingTypes = new Type[mp.Length];
 							for( int mpi = 0; mpi < mp.Length; mpi++ )
 							{
 								mpt[mpi] = mp[mpi].ParameterType;
+								nullableUnderlyingTypes[mpi] = Nullable.GetUnderlyingType(mpt[mpi]);
 							}
 							t.nativeParameterTypes = mpt;
+							t.nativeParameterNullableUnderlyingTypes = nullableUnderlyingTypes;
 							t.nativeIsVoid = (m is MethodInfo mInfo) && mInfo.ReturnType == typeof(void);
 							t.nativeIsSupportedNullableMethod = CilboxNullable.IsSupportedNullableMethod(m);
 						} else if( !t.isNative )

--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -540,11 +540,35 @@ spiperf.Begin();
 
 								if (callthis == null)
 								{
-									interpretedThrow(pc - 1, new NullReferenceException());
-									break;
+									Type nullableUnderlyingType = Nullable.GetUnderlyingType(t);
+									if( nullableUnderlyingType != null )
+									{
+										switch( mi.Name )
+										{
+										case "get_HasValue":
+											iko = false;
+											break;
+										case "GetValueOrDefault":
+											iko = callpar.Length == 0 ? Activator.CreateInstance(nullableUnderlyingType) : callpar[0];
+											break;
+										case "get_Value":
+											interpretedThrow(pc - 1, new InvalidOperationException("Nullable object must have a value."));
+											break;
+										default:
+											interpretedThrow(pc - 1, new NullReferenceException());
+											break;
+										}
+									}
+									else
+									{
+										interpretedThrow(pc - 1, new NullReferenceException());
+									}
+									if( iko == null ) break;
 								}
-
-								iko = st.Invoke( callthis, callpar );
+								else
+								{
+									iko = st.Invoke( callthis, callpar );
+								}
 								if( seorig.type == StackType.Address  && callthis is not BoxedCilboxEnum ) // enums are immutable
 								{
 									seorig.DereferenceLoadAddress( callthis );

--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -333,7 +333,62 @@ spiperf.Begin();
 					case 0x21: stackBuffer[++sp].LoadLong( (long)BytecodeAs64( ref pc ) ); break; // ldc.i8 <int64>
 					case 0x22: stackBuffer[++sp].LoadFloat( CilboxUtil.IntFloatConverter.ConvertUtoF(BytecodeAsU32( ref pc ) ) ); break; // ldc.r4 <float32 (num)>
 					case 0x23: stackBuffer[++sp].LoadDouble( CilboxUtil.IntFloatConverter.ConvertEtoD(BytecodeAs64( ref pc ) ) ); break; // ldc.r8 <float64 (num)>
-					// 0x24 does not exist.
+					case CilboxNullable.NullableCallOpcode: // cbx.nullable.call
+					{
+						int currentInstruction = pc - 1;
+						uint bc = BytecodeAsU32( ref pc );
+						CilMetadataTokenInfo dt = box.metadatas[bc];
+						if( dt == null || !dt.isValid || !dt.isNative || dt.nativeMethod == null || !dt.nativeIsSupportedNullableMethod )
+						{
+							throw new CilboxInterpreterRuntimeException("Invalid cbx.nullable.call target.", parentClass.className, methodName, currentInstruction);
+						}
+
+						MethodBase st = dt.nativeMethod;
+						MethodInfo mi = (MethodInfo)st;
+						Type nullableUnderlyingType = CilboxNullable.GetUnderlyingTypeOrThrow(mi);
+						Type[] paTypes = dt.nativeParameterTypes;
+						object fallbackValue = null;
+						if( paTypes.Length == 1 )
+						{
+							StackElement fallbackSe = stackBuffer[sp--];
+							fallbackValue = fallbackSe.AsObject(box);
+							if( fallbackValue != null && nullableUnderlyingType.IsValueType && fallbackValue.GetType() != nullableUnderlyingType )
+								fallbackValue = fallbackSe.CoerceToObject( nullableUnderlyingType );
+						}
+						else if( paTypes.Length != 0 )
+						{
+							throw new CilboxInterpreterRuntimeException("Invalid cbx.nullable.call parameter count.", parentClass.className, methodName, currentInstruction);
+						}
+
+						StackElement seorig = stackBuffer[sp--];
+						StackElement se = StackElement.ResolveToStackElement( seorig );
+						object nullableValue = se.AsObject(box);
+						if( nullableValue != null && se.type < StackType.Object )
+							nullableValue = se.CoerceToObject( nullableUnderlyingType );
+
+						bool hasValue = nullableValue != null;
+						switch( mi.Name )
+						{
+						case "get_HasValue":
+							stackBuffer[++sp].LoadInt( hasValue ? 1 : 0 );
+							break;
+						case "get_Value":
+							if( !hasValue )
+							{
+								interpretedThrow(currentInstruction, new InvalidOperationException("Nullable object must have a value."));
+								break;
+							}
+							stackBuffer[++sp].Load( nullableValue );
+							break;
+						case "GetValueOrDefault":
+							stackBuffer[++sp].Load( hasValue ? nullableValue : (paTypes.Length == 0 ? Activator.CreateInstance(nullableUnderlyingType) : fallbackValue) );
+							break;
+						default:
+							throw new CilboxInterpreterRuntimeException("Unsupported cbx.nullable.call target.", parentClass.className, methodName, currentInstruction);
+						}
+						constrainedMeta = null;
+						break;
+					}
 					case 0x25: stackBuffer[sp+1] = stackBuffer[sp]; sp++; break; // dup TODO: Does dup potentially duplicate objects somehow?
 					case 0x26: sp--; break; // pop
 
@@ -442,6 +497,10 @@ spiperf.Begin();
 						{
 							st = dt.nativeMethod;
 							isVoid = dt.nativeIsVoid;
+							if( dt.nativeIsSupportedNullableMethod )
+							{
+								throw new CilboxInterpreterRuntimeException(CilboxNullable.LegacyNullableCallMessage, parentClass.className, methodName, currentInstruction);
+							}
 							object callthis = null;
 							Type[] paTypes = dt.nativeParameterTypes;
 							int numFields = paTypes.Length;
@@ -498,6 +557,15 @@ spiperf.Begin();
 									}
 
 									Type ctorDeclaringType = ctor.DeclaringType;
+									if( ctorDeclaringType != null && Nullable.GetUnderlyingType(ctorDeclaringType) != null )
+									{
+										if( ctorThisSe.type == StackType.Address )
+											ctorThisSe.DereferenceLoadAddress( callpar.Length == 0 ? null : callpar[0] );
+										else if( ctorThisSe.type == StackType.NativeHandle )
+											ctorThisSe.DereferenceLoadNativeHandle( box, callpar.Length == 0 ? null : callpar[0] );
+										isVoid = true;
+										break;
+									}
 									if( ctorDeclaringType == null || ( ctorDeclaringType != typeof(object) && ctorDeclaringType != typeof(MonoBehaviour) ) )
 									{
 										throw new CilboxInterpreterRuntimeException(
@@ -540,30 +608,8 @@ spiperf.Begin();
 
 								if (callthis == null)
 								{
-									Type nullableUnderlyingType = Nullable.GetUnderlyingType(t);
-									if( nullableUnderlyingType != null )
-									{
-										switch( mi.Name )
-										{
-										case "get_HasValue":
-											iko = false;
-											break;
-										case "GetValueOrDefault":
-											iko = callpar.Length == 0 ? Activator.CreateInstance(nullableUnderlyingType) : callpar[0];
-											break;
-										case "get_Value":
-											interpretedThrow(pc - 1, new InvalidOperationException("Nullable object must have a value."));
-											break;
-										default:
-											interpretedThrow(pc - 1, new NullReferenceException());
-											break;
-										}
-									}
-									else
-									{
-										interpretedThrow(pc - 1, new NullReferenceException());
-									}
-									if( iko == null ) break;
+									interpretedThrow(pc - 1, new NullReferenceException());
+									break;
 								}
 								else
 								{
@@ -2035,6 +2081,7 @@ spiperf.End();
 		public MethodBase nativeMethod;
 		public Type[] nativeParameterTypes;
 		public bool nativeIsVoid;
+		public bool nativeIsSupportedNullableMethod;
 		public int interpretiveMethod; // If nativeToken is 0, then it's a interpreted call.
 		public int interpretiveMethodClass; // If nativeToken is 0, then it's a interpreted call class
 
@@ -2385,6 +2432,7 @@ spiperf.End();
 							}
 							t.nativeParameterTypes = mpt;
 							t.nativeIsVoid = (m is MethodInfo mInfo) && mInfo.ReturnType == typeof(void);
+							t.nativeIsSupportedNullableMethod = CilboxNullable.IsSupportedNullableMethod(m);
 						} else if( !t.isNative )
 						{
 							throw new CilboxException( "Error: Could not find reference to: [" + useAssembly + "][" + declaringType.FullName + "][" + fullSignature + "] Type from:" + declaringTypeName );
@@ -2881,6 +2929,12 @@ spiperf.End();
 											i = backupi;
 											assemblyMetadataReverseOriginal[(proxyAssembly, (int)operand)] = writebackToken;
 											CilboxUtil.BytecodeReplaceLiteral( ref byteCode, ref i, opLen, writebackToken );
+										}
+										if( (oc == CilboxUtil.OpCodes.Call || oc == CilboxUtil.OpCodes.Callvirt) && ot == CilboxUtil.OpCodes.OperandType.InlineMethod )
+										{
+											MethodBase targetMethod = proxyAssembly.ManifestModule.ResolveMethod( (int)operand );
+											if( CilboxNullable.IsSupportedNullableMethod(targetMethod) )
+												byteCode[starti] = CilboxNullable.NullableCallOpcode;
 										}
 										if( i >= byteCode.Length ) break;
 									} while( true );

--- a/Packages/com.cnlohr.cilbox/CilboxUtil.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxUtil.cs
@@ -185,8 +185,7 @@ namespace Cilbox
 				{
 					return null;
 				}
-
-				return CoerceToObject(nullableUnderlyingType);
+				t = nullableUnderlyingType;
 			}
 
 			StackType rt = StackTypeFromType( t );

--- a/Packages/com.cnlohr.cilbox/CilboxUtil.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxUtil.cs
@@ -219,15 +219,6 @@ namespace Cilbox
 
 		public object CoerceToObject( Type t )
 		{
-			Type nullableUnderlyingType = Nullable.GetUnderlyingType(t);
-			if( nullableUnderlyingType != null )
-			{
-				if( type == StackType.Object && o == null )
-				{
-					return null;
-				}
-				t = nullableUnderlyingType;
-			}
 
 			StackType rt = StackTypeFromType( t );
 
@@ -320,6 +311,18 @@ namespace Cilbox
 			}
 
 			throw new Exception( "Error invalid type conversion from " + type + " to " + t );
+		}
+		public object CoerceToObject( Type t, Type nullableUnderlyingType)
+		{
+			if( nullableUnderlyingType != null )
+			{
+				if( type == StackType.Object && o == null )
+				{
+					return null;
+				}
+				t = nullableUnderlyingType;
+			}
+			return CoerceToObject(t);
 		}
 
 		public object DereferenceAddress()

--- a/Packages/com.cnlohr.cilbox/CilboxUtil.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxUtil.cs
@@ -5,17 +5,58 @@ using System.Collections.Specialized;
 using System.Collections;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
+using System.Reflection;
 using System.Text;
 
 #if UNITY_EDITOR
 using UnityEditor;
 using UnityEditor.Callbacks;
-using System.Reflection;
 using System.IO;
 #endif
 
 namespace Cilbox
 {
+	public static class CilboxNullable
+	{
+		public const byte NullableCallOpcode = 0x24;
+		public const string LegacyNullableCallMessage = "Legacy serialized nullable call encountered. Rebuild serialized assembly data.";
+
+		private static bool IsNullableType(Type type)
+		{
+			return type != null && type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
+		}
+
+		public static bool IsSupportedNullableMethod(MethodBase method)
+		{
+			if( method == null )
+				return false;
+
+			Type declaringType = method.DeclaringType;
+			if( !IsNullableType(declaringType) )
+				return false;
+
+			switch( method.Name )
+			{
+			case "get_HasValue":
+			case "get_Value":
+				return method.GetParameters().Length == 0;
+			case "GetValueOrDefault":
+				ParameterInfo[] parameters = method.GetParameters();
+				return parameters.Length == 0 || parameters.Length == 1;
+			default:
+				return false;
+			}
+		}
+
+		public static Type GetUnderlyingTypeOrThrow(MethodBase method)
+		{
+			if( !IsSupportedNullableMethod(method) )
+				throw new InvalidOperationException("Unsupported nullable method: " + method);
+
+			return Nullable.GetUnderlyingType(method.DeclaringType);
+		}
+	}
+
 	///////////////////////////////////////////////////////////////////////////
 	//  STACK ELEMENT CONTAINER  //////////////////////////////////////////////
 	///////////////////////////////////////////////////////////////////////////
@@ -1475,6 +1516,7 @@ namespace Cilbox
 				Sizeof,
 				Refanytype,
 				Readonly,
+				Cbx_Nullable_Call,
 			}
 			public struct OpCode : IEquatable<OpCode> {
 
@@ -1753,6 +1795,10 @@ namespace Cilbox
 			public static readonly OpCode Ldc_R8 = new OpCode (
 				0xff << 0 | 0x23 << 8 | (byte) Code.Ldc_R8 << 16 | (byte) FlowControl.Next << 24,
 				(byte) OpCodeType.Primitive << 0 | (byte) OperandType.InlineR << 8 | (byte) StackBehaviour.Pop0 << 16 | (byte) StackBehaviour.Pushr8 << 24);
+
+			public static readonly OpCode Cbx_Nullable_Call = new OpCode (
+				0xff << 0 | 0x24 << 8 | (byte) Code.Cbx_Nullable_Call << 16 | (byte) FlowControl.Call << 24,
+				(byte) OpCodeType.Primitive << 0 | (byte) OperandType.InlineMethod << 8 | (byte) StackBehaviour.Varpop << 16 | (byte) StackBehaviour.Varpush << 24);
 
 			public static readonly OpCode Dup = new OpCode (
 				0xff << 0 | 0x25 << 8 | (byte) Code.Dup << 16 | (byte) FlowControl.Next << 24,
@@ -2712,9 +2758,10 @@ namespace Cilbox
 					6, 115, 105, 122, 101, 111, 102,
 					10, 114, 101, 102, 97, 110, 121, 116, 121, 112, 101,
 					9, 114, 101, 97, 100, 111, 110, 108, 121, 46,
+					17, 99, 98, 120, 46, 110, 117, 108, 108, 97, 98, 108, 101, 46, 99, 97, 108, 108,
 				};
 
-				names = new string [219];
+				names = new string [220];
 
 				for (int i = 0, p = 0; i < names.Length; i++) {
 					var buffer = new char [table [p++]];

--- a/Packages/com.cnlohr.cilbox/CilboxUtil.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxUtil.cs
@@ -178,6 +178,17 @@ namespace Cilbox
 
 		public object CoerceToObject( Type t )
 		{
+			Type nullableUnderlyingType = Nullable.GetUnderlyingType(t);
+			if( nullableUnderlyingType != null )
+			{
+				if( type == StackType.Object && o == null )
+				{
+					return null;
+				}
+
+				return CoerceToObject(nullableUnderlyingType);
+			}
+
 			StackType rt = StackTypeFromType( t );
 
 			if( t.IsEnum && type < StackType.Object )

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -49,6 +49,7 @@ namespace TestCilbox
 			"System.Numerics.Vector2",
 			"System.Object",
 			"System.Nullable",
+			"System.Nullable`1",
 			"System.Single",
 			"System.String",
 			"System.TimeSpan",
@@ -258,6 +259,16 @@ namespace TestCilbox
 		public static void GetOutInt(out int i)
 		{
 			i = 42;
+		}
+
+		public static void GetOutNullableInt(out int? i)
+		{
+			i = 42;
+		}
+
+		public static void GetOutNullableIntNull(out int? i)
+		{
+			i = null;
 		}
 
 		public static string NullablePrimitiveSummary(bool? flag, int? count, float? scale)
@@ -752,6 +763,10 @@ namespace TestCilbox
 			Validator.Validate("NativeOutVec3", "(12, 8, 0)");
 			Validator.Validate("CilOutVec3", "(1, 2, 3)");
 			Validator.Validate("NativeOutInt", "42");
+			Validator.Validate("NativeOutNullableIntHasValue", "True");
+			Validator.Validate("NativeOutNullableIntValue", "42");
+			Validator.Validate("NativeOutNullableIntNullHasValue", "False");
+			Validator.Validate("NativeOutNullableIntNullValue", "0");
 			Validator.Validate("CilOutInt", "22");
 			Validator.Validate("NativeOutVec3AlreadyInit", "(12, 8, 0)");
 			Validator.Validate("NullablePrimitiveCoerceValues", "True, 42, 1.5");

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -48,6 +48,8 @@ namespace TestCilbox
 			"System.NullReferenceException",
 			"System.Numerics.Vector2",
 			"System.Object",
+			"System.Nullable",
+			"System.Nullable`1",
 			"System.Single",
 			"System.String",
 			"System.TimeSpan",
@@ -256,6 +258,14 @@ namespace TestCilbox
 		public static void GetOutInt(out int i)
 		{
 			i = 42;
+		}
+
+		public static string NullablePrimitiveSummary(bool? flag, int? count, float? scale)
+		{
+			string flagText = flag.HasValue ? flag.Value.ToString() : "null";
+			string countText = count.HasValue ? count.Value.ToString() : "null";
+			string scaleText = scale.HasValue ? scale.Value.ToString() : "null";
+			return flagText + ", " + countText + ", " + scaleText;
 		}
 	}
 
@@ -734,6 +744,8 @@ namespace TestCilbox
 			Validator.Validate("NativeOutInt", "42");
 			Validator.Validate("CilOutInt", "22");
 			Validator.Validate("NativeOutVec3AlreadyInit", "(12, 8, 0)");
+			Validator.Validate("NullablePrimitiveCoerceValues", "True, 42, 1.5");
+			Validator.Validate("NullablePrimitiveCoerceNulls", "null, null, null");
 			Validator.Validate("PrivateBoolOutSuccess", "True");
 			Validator.Validate("PrivateBoolOutInt", "1111");
 			Validator.Validate("PrivateBoolOutAlreadyInitSuccess", "True");

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -52,6 +52,7 @@ namespace TestCilbox
 			"System.Single",
 			"System.String",
 			"System.TimeSpan",
+			"System.Type",
 			"System.UInt16",
 			"System.UInt32",
 			"System.ValueTuple",
@@ -265,6 +266,16 @@ namespace TestCilbox
 			string countText = count.HasValue ? count.Value.ToString() : "null";
 			string scaleText = scale.HasValue ? scale.Value.ToString() : "null";
 			return flagText + ", " + countText + ", " + scaleText;
+		}
+
+		public static int? GetNullableInt()
+		{
+			return 42;
+		}
+
+		public static Type GetNullableIntReturnType()
+		{
+			return typeof(TestUtil).GetMethod(nameof(GetNullableInt)).ReturnType;
 		}
 	}
 
@@ -745,6 +756,8 @@ namespace TestCilbox
 			Validator.Validate("NativeOutVec3AlreadyInit", "(12, 8, 0)");
 			Validator.Validate("NullablePrimitiveCoerceValues", "True, 42, 1.5");
 			Validator.Validate("NullablePrimitiveCoerceNulls", "null, null, null");
+			Validator.Validate("NullableReturnTypeIsNullable", "True");
+			Validator.Validate("NullableReturnTypeUnderlying", "System.Int32");
 			Validator.Validate("PrivateBoolOutSuccess", "True");
 			Validator.Validate("PrivateBoolOutInt", "1111");
 			Validator.Validate("PrivateBoolOutAlreadyInitSuccess", "True");

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -280,6 +280,16 @@ namespace TestCilbox
 			return flagText + ", " + countText + ", " + scaleText;
 		}
 
+		public static int PlainBoundaryKernel(int count, float scale, bool flag)
+		{
+			return flag ? count + (int)scale : count - (int)scale;
+		}
+
+		public static int NullableBoundaryKernel(int? count, float? scale, bool? flag)
+		{
+			return flag.GetValueOrDefault() ? count.GetValueOrDefault() + (int)scale.GetValueOrDefault() : count.GetValueOrDefault() - (int)scale.GetValueOrDefault();
+		}
+
 		public static int? GetNullableInt()
 		{
 			return 42;
@@ -328,6 +338,8 @@ namespace TestCilbox
 				$"Perf.{rootClass}.TrigUs",
 				$"Perf.{rootClass}.MatrixUs",
 				$"Perf.{rootClass}.PeerCallsUs",
+				$"Perf.{rootClass}.PlainBoundaryUs",
+				$"Perf.{rootClass}.NullableBoundaryUs",
 			};
 			foreach( string key in taskKeys )
 			{
@@ -355,6 +367,8 @@ namespace TestCilbox
 			Validator.ValidatePositiveLong($"Perf.{rootClass}.TrigUs");
 			Validator.ValidatePositiveLong($"Perf.{rootClass}.MatrixUs");
 			Validator.ValidatePositiveLong($"Perf.{rootClass}.PeerCallsUs");
+			Validator.ValidatePositiveLong($"Perf.{rootClass}.PlainBoundaryUs");
+			Validator.ValidatePositiveLong($"Perf.{rootClass}.NullableBoundaryUs");
 			Validator.ValidatePositiveLong($"Perf.{rootClass}.TotalUs");
 			Validator.ValidatePositiveLong($"Perf.{peerClass}.TotalUs");
 

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -40,6 +40,7 @@ namespace TestCilbox
 			"System.Exception",
 			"System.IDisposable",
 			"System.IndexOutOfRangeException",
+			"System.InvalidOperationException",
 			"System.Int16",
 			"System.Int32",
 			"System.Int64",
@@ -771,6 +772,26 @@ namespace TestCilbox
 			Validator.Validate("NativeOutVec3AlreadyInit", "(12, 8, 0)");
 			Validator.Validate("NullablePrimitiveCoerceValues", "True, 42, 1.5");
 			Validator.Validate("NullablePrimitiveCoerceNulls", "null, null, null");
+			Validator.Validate("NullableLocalValueHasValue", "True");
+			Validator.Validate("NullableLocalValueValue", "5");
+			Validator.Validate("NullableLocalValueDefault", "5");
+			Validator.Validate("NullableLocalValueDefault123", "5");
+			Validator.Validate("NullableLocalNullHasValue", "False");
+			Validator.Validate("NullableLocalNullDefault", "0");
+			Validator.Validate("NullableLocalNullDefault123", "123");
+			Validator.Validate("NullableLocalNullValueThrows", "InvalidOperationException");
+			Validator.Validate("NullableArgumentValueHasValue", "True");
+			Validator.Validate("NullableArgumentValueDefault", "5");
+			Validator.Validate("NullableArgumentValueDefault123", "5");
+			Validator.Validate("NullableArgumentNullHasValue", "False");
+			Validator.Validate("NullableArgumentNullDefault", "0");
+			Validator.Validate("NullableArgumentNullDefault123", "123");
+			Validator.Validate("NullableReturnValue", "31");
+			Validator.Validate("NullableReturnNullHasValue", "False");
+			Validator.Validate("NullableFieldHasValue", "True");
+			Validator.Validate("NullableFieldValue", "77");
+			Validator.Validate("NullableFieldNullHasValue", "False");
+			Validator.Validate("NullableFieldNullDefault123", "123");
 			Validator.Validate("NullableReturnTypeIsNullable", "True");
 			Validator.Validate("NullableReturnTypeUnderlying", "System.Int32");
 			Validator.Validate("PrivateBoolOutSuccess", "True");

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -49,7 +49,6 @@ namespace TestCilbox
 			"System.Numerics.Vector2",
 			"System.Object",
 			"System.Nullable",
-			"System.Nullable`1",
 			"System.Single",
 			"System.String",
 			"System.TimeSpan",

--- a/TestCilbox/TestCilboxable.cs
+++ b/TestCilbox/TestCilboxable.cs
@@ -538,6 +538,10 @@ namespace TestCilbox
 			Validator.Set("NativeOutVec3AlreadyInit", alreadyInit.ToString() );
 			Validator.Set("NullablePrimitiveCoerceValues", TestUtil.NullablePrimitiveSummary(true, 42, 1.5f) );
 			Validator.Set("NullablePrimitiveCoerceNulls", TestUtil.NullablePrimitiveSummary(null, null, null) );
+			Type nullableReturnType = TestUtil.GetNullableIntReturnType();
+			Type nullableUnderlyingType = Nullable.GetUnderlyingType(nullableReturnType);
+			Validator.Set("NullableReturnTypeIsNullable", (nullableUnderlyingType != null).ToString() );
+			Validator.Set("NullableReturnTypeUnderlying", nullableUnderlyingType.FullName );
 			bool privateOutSuccess = TryGetPrivateOutInt(out int privateOutInt);
 			Validator.Set("PrivateBoolOutSuccess", privateOutSuccess.ToString() );
 			Validator.Set("PrivateBoolOutInt", privateOutInt.ToString() );

--- a/TestCilbox/TestCilboxable.cs
+++ b/TestCilbox/TestCilboxable.cs
@@ -531,6 +531,12 @@ namespace TestCilbox
 			Validator.Set("CilOutVec3", outVec2.ToString() );
 			TestUtil.GetOutInt(out int outInt);
 			Validator.Set("NativeOutInt", outInt.ToString() );
+			TestUtil.GetOutNullableInt(out int? outNullableInt);
+			Validator.Set("NativeOutNullableIntHasValue", outNullableInt.HasValue.ToString() );
+			Validator.Set("NativeOutNullableIntValue", outNullableInt.GetValueOrDefault().ToString() );
+			TestUtil.GetOutNullableIntNull(out int? outNullableIntNull);
+			Validator.Set("NativeOutNullableIntNullHasValue", outNullableIntNull.HasValue.ToString() );
+			Validator.Set("NativeOutNullableIntNullValue", outNullableIntNull.GetValueOrDefault().ToString() );
 			TestOutInt(out int outInt2);
 			Validator.Set("CilOutInt", outInt2.ToString() );
 			Vector3 alreadyInit = new Vector3(5, 5, 5);

--- a/TestCilbox/TestCilboxable.cs
+++ b/TestCilbox/TestCilboxable.cs
@@ -30,6 +30,7 @@ namespace TestCilbox
 		public TestEnum testEnumField = TestEnum.SecondValue;
 		private TestState testStateField = TestState.Playing;
 		private TestPayload testPayloadField = new TestPayload { Score = 123, Lives = 4 };
+		private int? nullableField = 77;
 
 		public enum MyEnum
 		{
@@ -544,6 +545,7 @@ namespace TestCilbox
 			Validator.Set("NativeOutVec3AlreadyInit", alreadyInit.ToString() );
 			Validator.Set("NullablePrimitiveCoerceValues", TestUtil.NullablePrimitiveSummary(true, 42, 1.5f) );
 			Validator.Set("NullablePrimitiveCoerceNulls", TestUtil.NullablePrimitiveSummary(null, null, null) );
+			RunNullableMemberTests();
 			Type nullableReturnType = TestUtil.GetNullableIntReturnType();
 			Type nullableUnderlyingType = Nullable.GetUnderlyingType(nullableReturnType);
 			Validator.Set("NullableReturnTypeIsNullable", (nullableUnderlyingType != null).ToString() );
@@ -628,6 +630,57 @@ namespace TestCilbox
 			for( int i = 0; i < 10000000; i++ ) result = System.Math.Sin( result ) * 10.0;
 			Validator.Set( "Throwaway", result.ToString() );
 			Validator.Set( "Overtime", "did not timed out" );
+		}
+
+		private int? GetInterpretedNullable(bool hasValue)
+		{
+			return hasValue ? 31 : null;
+		}
+
+		private void RecordNullableArgument(string prefix, int? value)
+		{
+			Validator.Set(prefix + "HasValue", value.HasValue.ToString());
+			Validator.Set(prefix + "Default", value.GetValueOrDefault().ToString());
+			Validator.Set(prefix + "Default123", value.GetValueOrDefault(123).ToString());
+		}
+
+		private void RunNullableMemberTests()
+		{
+			int? localValue = 5;
+			Validator.Set("NullableLocalValueHasValue", localValue.HasValue.ToString());
+			Validator.Set("NullableLocalValueValue", localValue.Value.ToString());
+			Validator.Set("NullableLocalValueDefault", localValue.GetValueOrDefault().ToString());
+			Validator.Set("NullableLocalValueDefault123", localValue.GetValueOrDefault(123).ToString());
+
+			int? localNull = null;
+			Validator.Set("NullableLocalNullHasValue", localNull.HasValue.ToString());
+			Validator.Set("NullableLocalNullDefault", localNull.GetValueOrDefault().ToString());
+			Validator.Set("NullableLocalNullDefault123", localNull.GetValueOrDefault(123).ToString());
+			try
+			{
+#pragma warning disable CS8629
+				int ignored = localNull.Value;
+#pragma warning restore CS8629
+				Validator.Set("NullableLocalNullValueThrows", ignored.ToString());
+			}
+			catch(InvalidOperationException)
+			{
+				Validator.Set("NullableLocalNullValueThrows", "InvalidOperationException");
+			}
+
+			RecordNullableArgument("NullableArgumentValue", localValue);
+			RecordNullableArgument("NullableArgumentNull", localNull);
+
+			int? returnedValue = GetInterpretedNullable(true);
+			int? returnedNull = GetInterpretedNullable(false);
+			Validator.Set("NullableReturnValue", returnedValue.GetValueOrDefault().ToString());
+			Validator.Set("NullableReturnNullHasValue", returnedNull.HasValue.ToString());
+
+			Validator.Set("NullableFieldHasValue", nullableField.HasValue.ToString());
+			Validator.Set("NullableFieldValue", nullableField.GetValueOrDefault().ToString());
+			nullableField = null;
+			Validator.Set("NullableFieldNullHasValue", nullableField.HasValue.ToString());
+			Validator.Set("NullableFieldNullDefault123", nullableField.GetValueOrDefault(123).ToString());
 		}
 
 

--- a/TestCilbox/TestCilboxable.cs
+++ b/TestCilbox/TestCilboxable.cs
@@ -536,6 +536,8 @@ namespace TestCilbox
 			Vector3 alreadyInit = new Vector3(5, 5, 5);
 			TestUtil.GetOutVec3(out alreadyInit);
 			Validator.Set("NativeOutVec3AlreadyInit", alreadyInit.ToString() );
+			Validator.Set("NullablePrimitiveCoerceValues", TestUtil.NullablePrimitiveSummary(true, 42, 1.5f) );
+			Validator.Set("NullablePrimitiveCoerceNulls", TestUtil.NullablePrimitiveSummary(null, null, null) );
 			bool privateOutSuccess = TryGetPrivateOutInt(out int privateOutInt);
 			Validator.Set("PrivateBoolOutSuccess", privateOutSuccess.ToString() );
 			Validator.Set("PrivateBoolOutInt", privateOutInt.ToString() );

--- a/TestCilbox/TestCilboxable.cs
+++ b/TestCilbox/TestCilboxable.cs
@@ -965,6 +965,7 @@ namespace TestCilbox
 		private const int MatrixSize = 20;
 		private const int MatrixRepeats = 8;
 		private const int PeerCallCount = 2500;
+		private const int BoundaryCallCount = 50000;
 
 		public PerfPeerBehaviour peer;
 
@@ -979,11 +980,17 @@ namespace TestCilbox
 			long peerUs = RunPeerTask();
 
 			totalSw.Stop();
+			// Stopping watch to keep the same testing between versions.
+			long plainBoundaryUs = RunPlainBoundaryTask();
+			long nullableBoundaryUs = RunNullableBoundaryTask();
+
 			Validator.Set($"Perf.{ClassName}.RecursiveUs", recursiveUs.ToString());
 			Validator.Set($"Perf.{ClassName}.FourierUs", dftUs.ToString());
 			Validator.Set($"Perf.{ClassName}.TrigUs", trigUs.ToString());
 			Validator.Set($"Perf.{ClassName}.MatrixUs", matrixUs.ToString());
 			Validator.Set($"Perf.{ClassName}.PeerCallsUs", peerUs.ToString());
+			Validator.Set($"Perf.{ClassName}.PlainBoundaryUs", plainBoundaryUs.ToString());
+			Validator.Set($"Perf.{ClassName}.NullableBoundaryUs", nullableBoundaryUs.ToString());
 			Validator.Set($"Perf.{ClassName}.TotalUs", PerfUtility.StopwatchToUs(totalSw).ToString());
 		}
 
@@ -1128,6 +1135,32 @@ namespace TestCilbox
 			}
 			sw.Stop();
 			Validator.Set($"Perf.{ClassName}.PeerChecksum", value.ToString());
+			return PerfUtility.StopwatchToUs(sw);
+		}
+
+		private long RunPlainBoundaryTask()
+		{
+			System.Diagnostics.Stopwatch sw = System.Diagnostics.Stopwatch.StartNew();
+			int checksum = 0;
+			for (int i = 0; i < BoundaryCallCount; i++)
+			{
+				checksum += TestUtil.PlainBoundaryKernel(i, i * 0.25f, (i & 1) == 0);
+			}
+			sw.Stop();
+			Validator.Set($"Perf.{ClassName}.PlainBoundaryChecksum", checksum.ToString());
+			return PerfUtility.StopwatchToUs(sw);
+		}
+
+		private long RunNullableBoundaryTask()
+		{
+			System.Diagnostics.Stopwatch sw = System.Diagnostics.Stopwatch.StartNew();
+			int checksum = 0;
+			for (int i = 0; i < BoundaryCallCount; i++)
+			{
+				checksum += TestUtil.NullableBoundaryKernel(i, i * 0.25f, (i & 1) == 0);
+			}
+			sw.Stop();
+			Validator.Set($"Perf.{ClassName}.NullableBoundaryChecksum", checksum.ToString());
 			return PerfUtility.StopwatchToUs(sw);
 		}
 	}


### PR DESCRIPTION
This an attempt at using nullable opcode instead of normally checking every virt call if its a nullable.

* `CoerceToObject(Type t)` added overload if nullable during serialization, and should only be check if nullable metadata is true.