### PR TITLE
fix: cilbox modifies prefabs in editor

### DIFF
--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -3031,10 +3031,17 @@ spiperf.End();
 			perf.End(); perf = new ProfilerMarker( "Checking If Assembly Changed" ); perf.Begin();
 
 			Cilbox [] se = Resources.FindObjectsOfTypeAll(typeof(Cilbox)) as Cilbox [];
-			Cilbox tac;
-			if( se.Length != 0 )
+			Cilbox tac = null;
+
+			foreach ( var tacCandidate in se ) {
+				if ( tacCandidate.gameObject.scene.IsValid() && !EditorUtility.IsPersistent(tacCandidate)) {
+					tac = tacCandidate;
+					break;
+				}
+			}
+
+			if( tac != null )
 			{
-				tac = se[0];
 				if( tac.assemblyData != sAllAssemblyData ) EditorUtility.SetDirty( tac );
 			}
 			else

--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -3034,7 +3034,7 @@ spiperf.End();
 			Cilbox tac = null;
 
 			foreach ( var tacCandidate in se ) {
-				if ( tacCandidate.gameObject.scene.IsValid() && !EditorUtility.IsPersistent(tacCandidate)) {
+				if ( tacCandidate.gameObject.scene.IsValid() && !EditorUtility.IsPersistent(tacCandidate) ) {
 					tac = tacCandidate;
 					break;
 				}

--- a/TestCilbox/UnityEngine.cs
+++ b/TestCilbox/UnityEngine.cs
@@ -123,6 +123,7 @@ namespace UnityEngine
 	class EditorUtility
 	{
 		public static void SetDirty( MonoBehaviour m ) { }
+		public static bool IsPersistent( Object t ) { return false; }
 	}
 
 	namespace SceneManagement
@@ -226,6 +227,7 @@ namespace UnityEngine
 		public HideFlags hideFlags;
 		private readonly Transform _transform = new Transform();
 		public Transform transform => _transform;
+		public SceneManagement.Scene scene => new SceneManagement.Scene();
 
 		public T[] GetComponentsInChildren<T>( bool something ) { return AllComponents.ToArray().OfType<T>().ToArray(); }
 


### PR DESCRIPTION
context: https://discord.com/channels/1239242259392757822/1500881494346956892/1513364233084080179

While in Play mode in the Unity Editor, Cilbox may occasionally modify prefabs that are referenced in the scene.
This can cause fields such as `Disabled` or `interpreterAccountingCumulativeTicks` to be persisted unintentionally, causing the cilboxable MonoBehaviour to malfunction.
This issue is caused by `FindObjectsOfTypeAll` collecting objects regardless of whether they are present in the scene.