### PR TITLE
Fix inherited [Cilboxable] field layout and serialization (enumerate base-first, include inherited privates)

### DIFF
--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -3061,7 +3061,7 @@ spiperf.End();
 						if( lst == 0 )
 							fi = type.GetFields( BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static );
 						else
-							fi = type.GetFields( BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance );
+							fi = CilboxUtil.GetInstanceFieldsBaseFirst( type );
 						foreach( var f in fi )
 						{
 							Dictionary< String, Serializee > dictField = new Dictionary< String, Serializee >();

--- a/Packages/com.cnlohr.cilbox/CilboxProxy.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxProxy.cs
@@ -43,7 +43,7 @@ namespace Cilbox
 			cls = box.GetClass( className );
 
 			fieldsObjects = new List< UnityEngine.Object >();
-			FieldInfo[] fi = mToSteal.GetType().GetFields( BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance );
+			FieldInfo[] fi = CilboxUtil.GetInstanceFieldsBaseFirst( mToSteal.GetType() );
 
 			List< Serializee > lstObjects = new List< Serializee >();
 

--- a/Packages/com.cnlohr.cilbox/CilboxUtil.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxUtil.cs
@@ -1002,6 +1002,21 @@ namespace Cilbox
 			}
 			CLog.Close();
 		}
+
+		// Layout enumeration only -- field TYPES are not gated here. Every field type (inherited privates included) is
+		// validated at load in CilboxClass.LoadCilboxClass (GetNativeTypeFromSerializee -> CheckTypeAllowed), the real boundary.
+		public static FieldInfo[] GetInstanceFieldsBaseFirst( Type type )
+		{
+			List< FieldInfo > ordered = new List< FieldInfo >();
+			AddInstanceFieldsBaseFirst( type, ordered );
+			return ordered.ToArray();
+		}
+		static void AddInstanceFieldsBaseFirst( Type t, List< FieldInfo > into )
+		{
+			if( t == null || t == typeof( UnityEngine.MonoBehaviour ) || t == typeof( object ) ) return;
+			AddInstanceFieldsBaseFirst( t.BaseType, into );
+			into.AddRange( t.GetFields( BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly ) );
+		}
 #endif
 
 		///////////////////////////////////////////////////////////////////////////

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -96,6 +96,8 @@ namespace TestCilbox
 			"UnityEngine.Quaternion.z",
 			"UnityEngine.Quaternion.w",
 			"TestCilbox.TestUtil.StaticFloat",
+			"UnityEngine.Component.gameObject",
+			"UnityEngine.Behaviour.enabled",
 		};
 
 		static public HashSet<String> GetWhiteListTypes() { return whiteListType; }
@@ -380,6 +382,12 @@ namespace TestCilbox
 				PerfPeerBehaviour perfPeer = perfPeerGo.CreateComponent<PerfPeerBehaviour>();
 				perfRoot.peer = perfPeer;
 			}
+
+			GameObject inheritGo = new GameObject("InheritFieldToProxy");
+			InheritFieldDerived inheritDerived = inheritGo.CreateComponent<InheritFieldDerived>();
+
+			GameObject secFieldGo = new GameObject("SecFieldDerivedToProxy");
+			SecFieldDerived secFieldDerived = secFieldGo.CreateComponent<SecFieldDerived>();
 
 			GameObject getCompRowGo = new GameObject("GetComponentRowToProxy");
 			GetComponentRow getCompRow = getCompRowGo.CreateComponent<GetComponentRow>();
@@ -803,6 +811,20 @@ namespace TestCilbox
 			Validator.Validate("ThrowFromOtherBehaviour2", "caught");
 			Validator.Validate("ThrowFromOtherBehaviour2Finally", "finally");
 			Validator.Validate("ThrowFromOtherConstructor", "caught");
+
+			Cilbox.CilboxProxy inheritProxy = inheritGo.GetComponents<Cilbox.CilboxProxy>()[0];
+			InvokeProxyMethod( inheritProxy, "Start" );
+			Validator.Validate( "Inherit Base Field", "555" );
+			Validator.Validate( "Inherit Derived Field", "222" );
+
+			// Security (PR #95): an inherited PRIVATE field of a non-whitelisted type is rejected at load (type -> null), while a legal inherited field is kept.
+			Cilbox.CilboxClass secFieldCls = cb.GetClass("TestCilbox.SecFieldDerived");
+			int secIllegalIdx = secFieldCls != null ? System.Array.IndexOf(secFieldCls.instanceFieldNames, "secretIllegal") : -1;
+			int secLegalIdx = secFieldCls != null ? System.Array.IndexOf(secFieldCls.instanceFieldNames, "secretLegal") : -1;
+			Validator.Set("Sec Inherited Illegal Field Rejected", (secIllegalIdx >= 0 && secFieldCls.instanceFieldTypes[secIllegalIdx] == null).ToString());
+			Validator.Set("Sec Inherited Legal Field Kept", (secLegalIdx >= 0 && secFieldCls.instanceFieldTypes[secLegalIdx] != null).ToString());
+			Validator.Validate("Sec Inherited Illegal Field Rejected", "True");
+			Validator.Validate("Sec Inherited Legal Field Kept", "True");
 
 			Validator.Validate( "NativeStructCtor Vector2", "<3.5, 4.5>" );
 			Validator.Validate( "NativeStructCtor Quaternion x", "0.5" );

--- a/TestCilbox/TestCilboxable.cs
+++ b/TestCilbox/TestCilboxable.cs
@@ -1181,6 +1181,49 @@ namespace TestCilbox
 		}
 	}
 	[Cilboxable]
+	public class InheritFieldBase : MonoBehaviour
+	{
+		private int baseField = 111;
+		public void SetBaseField(int v) { baseField = v; }
+		public int GetBaseField() { return baseField; }
+	}
+
+	[Cilboxable]
+	public class InheritFieldDerived : InheritFieldBase
+	{
+		private int derivedField = 222;
+		public void Start()
+		{
+			SetBaseField(555);
+			Validator.Set("Inherit Base Field", GetBaseField().ToString());
+			Validator.Set("Inherit Derived Field", derivedField.ToString());
+		}
+	}
+	// Security (PR #95): base-first enumeration now includes inherited PRIVATE fields. A field whose TYPE
+	// is not whitelisted must still be rejected at load (its type resolves to null / the slot stays inert),
+	// so widening the enumeration can never expose an illegal-typed inherited field to interpreted code.
+	public class SecIllegalFieldType
+	{
+		public int payload = 7;
+	}
+
+	[Cilboxable]
+	public class SecFieldBase : MonoBehaviour
+	{
+		// Read via reflection at bake, never referenced in code; suppress unused/unassigned warnings.
+#pragma warning disable 0169, 0649, 0414
+		private SecIllegalFieldType secretIllegal;
+		private int secretLegal = 42;
+#pragma warning restore 0169, 0649, 0414
+	}
+
+	[Cilboxable]
+	public class SecFieldDerived : SecFieldBase
+	{
+		public int ownField = 1;
+	}
+
+	[Cilboxable]
 	public class GetComponentRowBase : MonoBehaviour
 	{
 		public int baseTag = 100;


### PR DESCRIPTION
**Bug:** When a `[Cilboxable]` script inherits from another `[Cilboxable]` script, inherited fields are numbered subclass-first and inherited *private* fields are dropped entirely — a base-class method's field write lands on the wrong slot (typically `TargetException: Object does not match target type`), and an inherited private `[SerializeField]` reference loads null even though it's set in the scene. Bakes clean; both fail only at runtime.

**Cause:** Both the exporter's class-metadata field table and the proxy serialize loop (`CilboxProxy.SetupProxy`) enumerate with `GetFields(...Instance)`, which orders derived-first and omits inherited private fields.

**Fix:** Enumerate fields base-class-first per hierarchy level (`DeclaredOnly`, including inherited privates) in both places, so each class's field indices form a stable base-first prefix matching CLR layout and every inherited field is serialized.
