### PR TITLE
Implement starg.s (IL opcode 0x10, store-to-parameter)

### DIFF
--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -308,6 +308,7 @@ spiperf.Begin();
 					case 0x0d: stackBuffer[localVarsHead+3] = stackBuffer[sp--]; break; //stloc.3
 					case 0x0e: stackBuffer[++sp] = parameters[byteCode[pc++]]; break; // ldarg.s <uint8 (argNum)>
 					case 0x0f: stackBuffer[++sp] = StackElement.CreateAddressReference( parametersIn.Array, (uint)parametersIn.Offset + (uint)byteCode[pc++] ); break; // ldarga.s <uint8 (argNum)>
+					case 0x10: parameters[byteCode[pc++]] = stackBuffer[sp--]; break; // starg.s <uint8 (argNum)> -- mirror of stloc.s (0x13) but stores into a parameter slot
 					case 0x11: stackBuffer[++sp] = stackBuffer[localVarsHead+byteCode[pc++]]; break; //ldloc.s
 					case 0x12:
 					{

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -791,6 +791,8 @@ namespace TestCilbox
 			Validator.Validate( "Empty String Field Null", "False" );
 			Validator.Validate( "Empty String Field Length", "0" );
 
+			Validator.Validate( "StargClamp", "210" );
+
 			return -1 * Validator.NumValidationErrors();
 		}
 	}

--- a/TestCilbox/TestCilboxable.cs
+++ b/TestCilbox/TestCilboxable.cs
@@ -627,6 +627,8 @@ namespace TestCilbox
 
 			Validator.Set("Empty String Field Null", (emptyStringField == null).ToString());
 			Validator.Set("Empty String Field Length", emptyStringField != null ? emptyStringField.Length.ToString() : "null");
+
+			Validator.Set("StargClamp", StargClamp(5).ToString());
 		}
 
 		public void Update()
@@ -826,6 +828,14 @@ namespace TestCilbox
 		{
 			i = 22;
 		}
+
+		public int StargClamp(int y)
+		{
+			y += 100;
+			y *= 2;
+			return y;
+		}
+
 	}
 
 


### PR DESCRIPTION
**Bug:** Any interpreted method that assigns to one of its parameters throws `CilboxInterpreterRuntimeException: Opcode 0x10 unimplemented`, because `starg.s` (store-to-parameter) is missing from the opcode switch, which jumps from `0x0f` straight to `0x11`.

**Fix:** Add the `0x10` case — the exact mirror of `stloc.s` (`0x13`) but storing the stack top into the parameter slot instead of a local.
