### PR TITLE
Virtual dispatch for callvirt (0x6F) and ldvirtftn (0xFE 0x07)

### DIFF
--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -389,6 +389,25 @@ spiperf.Begin();
 								if( targetMethod == null )
 									throw new CilboxInterpreterRuntimeException($"Function {dt.Name} not found", parentClass.className, methodName, pc);
 
+								// callvirt (0x6F) dispatches on the receiver's runtime type; plain call (0x28) and base.X() must stay
+								// bound to the token's method, and statics/ctors have no virtual receiver -- so only re-resolve here.
+								if( b == 0x6F && !targetMethod.isStatic && !targetMethod.isConstructor )
+								{
+									// Args are still on the stack, so the receiver 'this' sits just below them, at sp - (parameter count).
+									int vparams = targetMethod.signatureParameters.Length;
+									object oThis = stackBuffer[sp - vparams].AsObject( box );
+									// Receiver's actual runtime class: interpreted proxy or heap object (null for a native/null receiver).
+									CilboxClass rtClass = (oThis as CilboxProxy)?.cls;
+									if( rtClass == null ) rtClass = (oThis as CilboxHeapInstance)?.cls;
+									// If that class overrides this method (same signature, more-derived), re-bind the call to the override.
+									if( rtClass != null && rtClass != targetClass &&
+										rtClass.methodFullSignatureToIndex.TryGetValue( targetMethod.fullSignature, out uint vidx ) )
+									{
+										targetClass = rtClass;
+										targetMethod = targetClass.methods[(int)vidx];
+									}
+								}
+
 								isVoid = targetMethod.isVoid;
 								int staticOffset = (targetMethod.isStatic?0:1);
 								int numParams = targetMethod.signatureParameters.Length;
@@ -1634,6 +1653,32 @@ spiperf.Begin();
 								throw new CilboxInterpreterRuntimeException($"Cannot create references to functions outside this cilbox ({dt.Name})", parentClass.className, methodName, pc);
 							stackBuffer[++sp].LoadObject( box.classesList[dt.interpretiveMethodClass].methods[dt.interpretiveMethod] );
 							break;
+						case 0x07: // ldvirtftn: function pointer to the receiver's runtime-class override (for a delegate over a virtual method)
+						{
+							// ldvirtftn is like ldftn (0x06) but resolves the target by the receiver's runtime type: it pushes a
+							// pointer to the virtual override of <method> for the object on top of the stack (used to build a delegate).
+							uint bcv = BytecodeAsU32( ref pc );
+							CilMetadataTokenInfo dtv = box.metadatas[bcv];
+							// We can only make pointers to methods that live inside this cilbox.
+							if( dtv.isNative )
+								throw new CilboxInterpreterRuntimeException($"Cannot create references to functions outside this cilbox ({dtv.Name})", parentClass.className, methodName, pc);
+							// Start from the token's method (the base declaration) -- the fallback if the receiver doesn't override it.
+							CilboxClass vClass = box.classesList[dtv.interpretiveMethodClass];
+							CilboxMethod vMethod = vClass.methods[dtv.interpretiveMethod];
+							// Pop the receiver and find its runtime class.
+							object vThis = stackBuffer[sp--].AsObject( box );
+							CilboxClass vrtClass = (vThis as CilboxProxy)?.cls;
+							if( vrtClass == null ) vrtClass = (vThis as CilboxHeapInstance)?.cls;
+							// If the runtime class overrides the method (same signature, more-derived), point vMethod at the override.
+							if( vrtClass != null && vrtClass != vClass && vMethod != null &&
+								vrtClass.methodFullSignatureToIndex.TryGetValue( vMethod.fullSignature, out uint vmidx ) )
+							{
+								vMethod = vrtClass.methods[(int)vmidx];
+							}
+							// Push the resolved method as the function pointer (later consumed to build the delegate).
+							stackBuffer[++sp].LoadObject( vMethod );
+							break;
+						}
 						case 0x15: // initobj <typeTok>
 						{
 							uint typeToken = BytecodeAsU32( ref pc );

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -370,6 +370,9 @@ namespace TestCilbox
 			cycleRoot.child = cycleChild;
 			cycleChild.root = cycleRoot;
 
+			GameObject virtualGo = new GameObject("VirtualDispatchToProxy");
+			VirtualDispatchDerived virtualDerived = virtualGo.CreateComponent<VirtualDispatchDerived>();
+
 			GameObject perfRootGo = null;
 			GameObject perfPeerGo = null;
 			if( runPerf )
@@ -809,6 +812,10 @@ namespace TestCilbox
 			Validator.Validate( "NativeStructCtor Quaternion y", "0.25" );
 			Validator.Validate( "NativeStructCtor Quaternion z", "0.75" );
 			Validator.Validate( "NativeStructCtor Quaternion w", "1" );
+
+			Cilbox.CilboxProxy virtualProxy = virtualGo.GetComponents<Cilbox.CilboxProxy>()[0];
+			InvokeProxyMethod( virtualProxy, "Start" );
+			Validator.Validate( "Virtual Dispatch", "derived" );
 
 			Validator.Validate( "Char Trailing Eq", "2" );
 			Validator.Validate( "Char Code A", "65" );

--- a/TestCilbox/TestCilboxable.cs
+++ b/TestCilbox/TestCilboxable.cs
@@ -927,6 +927,23 @@ namespace TestCilbox
 	}
 
 	[Cilboxable]
+	public class VirtualDispatchBase : MonoBehaviour
+	{
+		public string RunVirtual() { return Describe(); }
+		protected virtual string Describe() { return "base"; }
+	}
+
+	[Cilboxable]
+	public class VirtualDispatchDerived : VirtualDispatchBase
+	{
+		protected override string Describe() { return "derived"; }
+		public void Start()
+		{
+			Validator.Set("Virtual Dispatch", RunVirtual());
+		}
+	}
+
+	[Cilboxable]
 	public class CycleRootBehaviour : MonoBehaviour
 	{
 		public CycleChildBehaviour child;


### PR DESCRIPTION
**Bug:** A `callvirt` to an overridden virtual silently runs the base method instead of the override — e.g. a base class's `Start()` calling `this.OnStart()` never reaches a `[Cilboxable]` subclass's `OnStart` override — and using a virtual method as a method group (to build a delegate) throws `Opcode 0xfe 0x07 unimplemented`. Bakes clean; the first silently runs the wrong method, the second faults at runtime.

**Cause:** The interpreter resolves virtual methods from the static IL token's declaring type, with no vtable / runtime-type dispatch. `call` and `callvirt` (`0x6F`) are resolved identically, so a `callvirt` to an override runs the base; and `ldvirtftn` (`0xFE 0x07`) — which loads the function pointer for a delegate over a virtual method — is unimplemented.

**Fix:** For `callvirt` on an interpreted instance method, re-resolve the target against the receiver's actual runtime class (same signature in its flattened method table, which holds the most-derived override); `call` / `base.X()` stays non-virtual. Implement `ldvirtftn` the same way as `ldftn` but pop the receiver and resolve the override against its runtime class, falling back to the token's method when there's none.
