### PR TITLE
Polymorphic GetComponent<T>/TryGetComponent<T> for [Cilboxable] types

### DIFF
--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -1900,12 +1900,23 @@ spiperf.End();
 
 		public uint [] importFunctionToId; // from ImportFunctionID
 
+		public String [] baseClassNames = new String[0];
+
 		public bool LoadCilboxClass( Cilbox box, String className, Serializee classData )
 		{
 			this.box = box;
 			this.className = className;
 
 			Dictionary<String, Serializee> classProps = classData.AsMap();
+
+			if( classProps.TryGetValue( "baseClasses", out Serializee baseClassesSer ) )
+			{
+				// deserialize the cilboxable base-class name list (for polymorphic GetComponent<Base> matching)
+				Serializee [] bcArr = baseClassesSer.AsArray();
+				baseClassNames = new String[bcArr.Length];
+				for( int bci = 0; bci < bcArr.Length; bci++ )
+					baseClassNames[bci] = bcArr[bci].AsString();
+			}
 
 			uint id = 0;
 			Serializee [] staticFields = classProps["staticFields"].AsArray();
@@ -3010,6 +3021,14 @@ spiperf.End();
 					}
 
 					classProps["methods"] = allClassMethods[type.FullName];
+
+					// Only [Cilboxable] ancestors are recorded: a native/prohibited base is never emitted, so GetComponent<T>
+					// base-matching can never name a non-sandboxed class (and a match only ever yields an interpreted proxy).
+					List< Serializee > baseClassChain = new List< Serializee >();
+					for( Type bt = type.BaseType; bt != null && bt != typeof( UnityEngine.MonoBehaviour ) && bt != typeof( object ); bt = bt.BaseType )
+						if( CilboxUtil.HasCilboxableAttribute( bt ) )
+							baseClassChain.Add( new Serializee( bt.FullName ) );
+					classProps["baseClasses"] = new Serializee( baseClassChain.ToArray() );
 					classes[type.FullName] = new Serializee( classProps );
 					perfType.End();
 				}

--- a/Packages/com.cnlohr.cilbox/CilboxUsage.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxUsage.cs
@@ -164,8 +164,11 @@ namespace Cilbox
 				CilboxProxy [] comps = ((GameObject)o).GetComponents<CilboxProxy>();
 				foreach( CilboxProxy p in comps )
 				{
-					if( p.className == compName )
+					CilboxClass pcls = p.cls != null ? p.cls : cls.box.GetClass( p.className );
+					if( p.className == compName || ( pcls != null && pcls.baseClassNames != null && System.Array.IndexOf( pcls.baseClassNames, compName ) >= 0 ) )
 					{
+						// force-load the matched proxy so it's usable when returned; RuntimeProxyLoad no-ops if already loaded (guards on proxyWasSetup)
+						p.RuntimeProxyLoad();
 						ret.Load( p );
 						break;
 					}
@@ -225,8 +228,11 @@ namespace Cilbox
 				CilboxProxy [] comps = ((GameObject)o).GetComponents<CilboxProxy>();
 				foreach( CilboxProxy p in comps )
 				{
-					if( p.className == compName && parameters[1].type == StackType.Address )
+					CilboxClass pcls = p.cls != null ? p.cls : cls.box.GetClass( p.className );
+					if( ( p.className == compName || ( pcls != null && pcls.baseClassNames != null && System.Array.IndexOf( pcls.baseClassNames, compName ) >= 0 ) ) && parameters[1].type == StackType.Address )
 					{
+						// force-load the matched proxy so it's usable when returned; RuntimeProxyLoad no-ops if already loaded (guards on proxyWasSetup)
+						p.RuntimeProxyLoad();
 						ret.Load( true );
 						parameters[1].DereferenceLoadAddress( p );
 						break;

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -379,6 +379,15 @@ namespace TestCilbox
 				perfRoot.peer = perfPeer;
 			}
 
+			GameObject getCompRowGo = new GameObject("GetComponentRowToProxy");
+			GetComponentRow getCompRow = getCompRowGo.CreateComponent<GetComponentRow>();
+			GameObject getCompDriverGo = new GameObject("GetComponentDriverToProxy");
+			GetComponentDriver getCompDriver = getCompDriverGo.CreateComponent<GetComponentDriver>();
+			getCompDriver.rowHolder = getCompRowGo;
+
+			GameObject secInheritsGo = new GameObject("SecInheritsProhibitedToProxy");
+			SecInheritsProhibited secInherits = secInheritsGo.CreateComponent<SecInheritsProhibited>();
+
 			GameObject cbobj = new GameObject("BasicCilbox");
 			Cilbox.Cilbox cb = cbobj.AddComponent<CilboxTester>();
 			cb.exportDebuggingData = true;
@@ -792,6 +801,17 @@ namespace TestCilbox
 			Validator.Validate( "Empty String Field Length", "0" );
 
 			Validator.Validate( "StargClamp", "210" );
+
+			Cilbox.CilboxProxy getCompDriverProxy = getCompDriverGo.GetComponents<Cilbox.CilboxProxy>()[0];
+			InvokeProxyMethod( getCompDriverProxy, "Start" );
+			Validator.Validate( "GetComponent Polymorphic Tag", "100" );
+
+			// Security (PR #98): the baked base-class chain records the [Cilboxable] ancestor but NOT the prohibited (non-[Cilboxable]) one.
+			Cilbox.CilboxClass secInheritsCls = cb.GetClass("TestCilbox.SecInheritsProhibited");
+			Validator.Set("Sec BaseClasses Has Cilboxable Ancestor", (secInheritsCls != null && System.Array.IndexOf(secInheritsCls.baseClassNames, "TestCilbox.SecCilboxableMid") >= 0).ToString());
+			Validator.Set("Sec BaseClasses Omits Prohibited Ancestor", (secInheritsCls != null && System.Array.IndexOf(secInheritsCls.baseClassNames, "TestCilbox.SecProhibitedBase") < 0).ToString());
+			Validator.Validate("Sec BaseClasses Has Cilboxable Ancestor", "True");
+			Validator.Validate("Sec BaseClasses Omits Prohibited Ancestor", "True");
 
 			return -1 * Validator.NumValidationErrors();
 		}

--- a/TestCilbox/TestCilboxable.cs
+++ b/TestCilbox/TestCilboxable.cs
@@ -1115,4 +1115,44 @@ namespace TestCilbox
 			return PerfUtility.StopwatchToUs(sw);
 		}
 	}
+	[Cilboxable]
+	public class GetComponentRowBase : MonoBehaviour
+	{
+		public int baseTag = 100;
+	}
+
+	[Cilboxable]
+	public class GetComponentRow : GetComponentRowBase
+	{
+	}
+
+	[Cilboxable]
+	public class GetComponentDriver : MonoBehaviour
+	{
+		public GameObject rowHolder;
+		public void Start()
+		{
+			GetComponentRowBase row = rowHolder.GetComponent<GetComponentRowBase>();
+			int tag = -1;
+			try { tag = row.baseTag; } catch (NullReferenceException) { tag = -2; }
+			Validator.Set("GetComponent Polymorphic Tag", tag.ToString());
+		}
+	}
+	// Security (PR #98): a [Cilboxable] class that derives through a NON-[Cilboxable] base must not record
+	// that base in its baseClasses chain, so polymorphic GetComponent<Base> can never name / back-call into it.
+	public class SecProhibitedBase : MonoBehaviour
+	{
+		public int prohibitedTag = 999;
+	}
+
+	[Cilboxable]
+	public class SecCilboxableMid : SecProhibitedBase
+	{
+	}
+
+	[Cilboxable]
+	public class SecInheritsProhibited : SecCilboxableMid
+	{
+		public int derivedTag = 5;
+	}
 }


### PR DESCRIPTION
**Bug:** `GetComponent<T>()` / `TryGetComponent<T>()` for a `[Cilboxable]` `T` returns null when the component's actual class is a subclass of `T`, and a component fetched from a just-`Instantiate`d clone NREs when used the same frame because the clone isn't loaded until its own `Start`.

**Cause:** Proxies are matched by exact class name only, with no notion of inheritance (the same inheritance-blindness as #97), and a freshly instantiated proxy isn't force-loaded before use.

**Fix:** Bake each class's cilboxable base-class chain (new `baseClasses` key → `CilboxClass.baseClassNames`, empty for older bakes so it stays backward compatible) and match exact-or-base class, then force-load the matched proxy (`RuntimeProxyLoad`) before returning it.
