### PR TITLE
Hold ProfilerMarker.Auto() scope in a using (fix Missing Profiler.EndSample)

### DIFF
--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -2102,7 +2102,7 @@ spiperf.End();
 		{
 #if UNITY_EDITOR
 			var pfm = new ProfilerMarker( "Initialize Cilbox" );
-			pfm.Auto();
+			using var pfmScope = pfm.Auto();
 #endif
 
 			if( initialized ) return;

--- a/Packages/com.cnlohr.cilbox/CilboxProxy.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxProxy.cs
@@ -204,7 +204,7 @@ namespace Cilbox
 				bool verboseLogging = box.verboseLogging;
 
 #if UNITY_EDITOR
-				new ProfilerMarker($"Initialize {className}").Auto();
+				using var initMarker = new ProfilerMarker($"Initialize {className}").Auto();
 #endif
 				var sb = new System.Text.StringBuilder("/" + transform.name);
 				Transform aparent = transform.parent;

--- a/TestCilbox/UnityEngine.cs
+++ b/TestCilbox/UnityEngine.cs
@@ -13,7 +13,8 @@ namespace Unity
 		{
 			public ProfilerMarker( String s ) { }
 			public void Begin() { }
-			public void Auto() { }
+			public AutoScope Auto() { return new AutoScope(); }
+			public struct AutoScope : IDisposable { public void Dispose() { } }
 			public void End() { }
 		}
 	}


### PR DESCRIPTION
**Bug:** Two `ProfilerMarker.Auto()` calls discard the returned `AutoScope`, so the sample never ends and the editor logs `Missing Profiler.EndSample (...)` — harmless console noise (`ProfilerMarker` is editor/development-only) that can mask real errors.

**Cause:** `.Auto()` calls `Begin()` immediately and `End()` only when the scope is disposed, but the scope was dropped instead of held in a `using`.

**Fix:** Hold each `AutoScope` in a `using` declaration in `CilboxProxy.RuntimeProxyLoad` and `Cilbox.BoxInitialize` so the sample ends at scope exit.
