### PR TITLE
Correct value-type boxing round-trips: box (0x8c) + isinst/castclass (0x74/0x75) + unbox.any (0xA5)

### DIFF
--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -1000,7 +1000,17 @@ spiperf.Begin();
 						else if( ti.nativeTypeIsStackType )
 						{
 							if( StackElement.TypeToStackType.TryGetValue( ti.Name, out StackType stackType ) && ti.nativeTypeStackType == stackType )
-								oRet = se.AsObject();
+							{
+								if( se.type == StackType.Object ) // boxed value: keep it only if it's genuinely the target type; else oRet stays null (isinst -> pushes null, castclass -> throws below)
+								{
+									if( se.o != null && ti.nativeType != null && ti.nativeType.IsInstanceOfType( se.o ) )
+										oRet = se.o;
+								}
+								else if( se.type == stackType )
+								{
+									oRet = se.AsObject();
+								}
+							}
 						}
 						else if( se.o != null && se.o.GetType() == ti.nativeType )
 							oRet = se.o;
@@ -1300,6 +1310,8 @@ spiperf.Begin();
 							stackBuffer[sp].LoadObject( meta.cilboxEnum.BoxValue( stackBuffer[sp].l ) );
 						else if( meta.nativeType != null && meta.nativeType.IsEnum )
 							stackBuffer[sp].LoadObject( Enum.ToObject(meta.nativeType, stackBuffer[sp].l) );
+						else if( meta.nativeTypeIsStackType && meta.nativeType != null )
+							stackBuffer[sp].LoadObject( stackBuffer[sp].CoerceToObject( meta.nativeType ) );
 						else
 							stackBuffer[sp].LoadObject( stackBuffer[sp].AsObject() );
 						break;
@@ -1517,6 +1529,13 @@ spiperf.Begin();
 						{
 							stackBuffer[sp].Unbox( stackBuffer[sp].AsObject(), metaType.nativeTypeStackType );
 						}
+						else if( metaType.nativeType != null && !metaType.nativeType.IsEnum )
+						{
+							object ubObj = stackBuffer[sp].AsObject();
+							if( ubObj != null && !metaType.nativeType.IsInstanceOfType( ubObj ) )
+								throw new InvalidCastException( $"unbox.any: {ubObj.GetType()} is not assignable to {metaType.nativeType}" );
+							stackBuffer[sp].LoadObject( ubObj );
+						}
 						else
 						{
 							throw new CilboxInterpreterRuntimeException($"Scary Unbox (that we don't have code for) from {otyp} ORIG {metaType.ToString()}", parentClass.className, methodName, pc);
@@ -1599,6 +1618,13 @@ spiperf.Begin();
 									case StackType.Ulong:	stackBuffer[sp].LoadInt( sa.e > sb.e ? 1 : 0 ); break;
 									case StackType.Float:	stackBuffer[sp].LoadInt( sa.f > sb.f ? 1 : 0 ); break;
 									case StackType.Double:	stackBuffer[sp].LoadInt( sa.d > sb.d ? 1 : 0 ); break;
+									case StackType.Object:
+										// cgt.un on object refs is how Roslyn emits `x != null` (an identity test, not an ordering); mirror ceq's guarded object case, fail on anything else
+										if( sa.type == StackType.Object && sb.type == StackType.Object )
+											stackBuffer[sp].LoadInt( sa.o != sb.o ? 1 : 0 );
+										else
+											throw new CilboxInterpreterRuntimeException($"CGT.UN Unimplemented type promotion unequal {sa.type} != {sb.type}", parentClass.className, methodName, pc);
+										break;
 									default: throw new CilboxInterpreterRuntimeException($"CEQ Unimplemented type promotion ({promoted})", parentClass.className, methodName, pc);
 								} break;
 							case 0x04: // CLT

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -825,6 +825,14 @@ namespace TestCilbox
 
 			Validator.Validate( "StargClamp", "210" );
 
+			Validator.Validate( "Box Bool RoundTrip", "True" );
+
+			Validator.Validate( "isinst BoxedFloat is bool", "False" );
+			Validator.Validate( "isinst BoxedFloat is int", "False" );
+			Validator.Validate( "isinst BoxedFloat is float", "True" );
+			Validator.Validate( "isinst BoxedInt is bool", "False" );
+			Validator.Validate( "isinst BoxedInt is int", "True" );
+
 			Cilbox.CilboxProxy getCompDriverProxy = getCompDriverGo.GetComponents<Cilbox.CilboxProxy>()[0];
 			InvokeProxyMethod( getCompDriverProxy, "Start" );
 			Validator.Validate( "GetComponent Polymorphic Tag", "100" );

--- a/TestCilbox/TestCilboxable.cs
+++ b/TestCilbox/TestCilboxable.cs
@@ -676,6 +676,19 @@ namespace TestCilbox
 			Validator.Set("Empty String Field Length", emptyStringField != null ? emptyStringField.Length.ToString() : "null");
 
 			Validator.Set("StargClamp", StargClamp(5).ToString());
+
+			bool boxFlag = true;
+			object boxBoxed = boxFlag;
+			bool boxBack = (bool)boxBoxed;
+			Validator.Set("Box Bool RoundTrip", boxBack.ToString());
+
+			object boxedFloatArg = 2.5f;
+			Validator.Set("isinst BoxedFloat is bool", (boxedFloatArg is bool).ToString());
+			Validator.Set("isinst BoxedFloat is int", (boxedFloatArg is int).ToString());
+			Validator.Set("isinst BoxedFloat is float", (boxedFloatArg is float).ToString());
+			object boxedIntArg = 7;
+			Validator.Set("isinst BoxedInt is bool", (boxedIntArg is bool).ToString());
+			Validator.Set("isinst BoxedInt is int", (boxedIntArg is int).ToString());
 		}
 
 		public void Update()


### PR DESCRIPTION
**Bug:** Value types don't survive a round-trip through `object`. Boxing a value type — e.g. a `bool` passed through a `params object[]` — throws `InvalidCastException` on unbox; testing a boxed value with `is` against a type it isn't matches the wrong arm; and unboxing a non-primitive value type such as a `Vector3` throws `Scary Unbox`. Bakes clean; faults only at runtime.

**Cause:** Three opcodes. IL widens `bool`/`short`/etc. to `int32` on the stack; `box` (`0x8c`) boxed that widened value instead of the operand's target type, so `box bool` produced a boxed `int` and `unbox.any bool` threw. `isinst`/`castclass` (`0x74`/`0x75`) to a stack-type matched unconditionally, returning the operand without checking its type, so the first arm of an `if (a is bool) … else if (a is int) …` chain matched any boxed value. `unbox.any` (`0xA5`) had no case for a non-stack native type and threw `Scary Unbox`.

**Fix:** `box` boxes to the operand type, re-narrowing the widened value per CLR `box <T>` semantics. `isinst`/`castclass` matches only when the operand's actual type is the target. `unbox.any` yields the already-boxed object for non-stack native types, throwing only on a genuine mismatch.

**Related:** #105, #106
