### PR TITLE
Load empty serialized value-types and strings as their default instead of null

### DIFF
--- a/Packages/com.cnlohr.cilbox/CilboxUtil.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxUtil.cs
@@ -690,10 +690,9 @@ namespace Cilbox
 				return TypeDescriptor.GetConverter(t).ConvertFrom(sInitialize);
 			else
 			{
-				if( !t.IsPrimitive )
-					return null;
-				else
+				if( t.IsValueType )
 					return Activator.CreateInstance(t);
+				return t == typeof(string) ? string.Empty : null;
 			}
 		}
 

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -767,6 +767,9 @@ namespace TestCilbox
 				RunPerfSuite(cb, perfRootProxy, perfPeerProxy);
 			}
 
+			Validator.Validate( "Empty String Field Null", "False" );
+			Validator.Validate( "Empty String Field Length", "0" );
+
 			return -1 * Validator.NumValidationErrors();
 		}
 	}

--- a/TestCilbox/TestCilboxable.cs
+++ b/TestCilbox/TestCilboxable.cs
@@ -14,6 +14,7 @@ namespace TestCilbox
 	public class TestCilboxBehaviour : MonoBehaviour
 	{
 		private int ipriviateinance = 555;
+		public string emptyStringField = "";
 		public int ipublicinstance = 556;
 		static private int iprivatestatic = 557;
 		static public int ipublicstatic = 558;
@@ -606,6 +607,9 @@ namespace TestCilbox
 			{
 				Validator.Set("ThrowFromOtherConstructor", "caught");
 			}
+
+			Validator.Set("Empty String Field Null", (emptyStringField == null).ToString());
+			Validator.Set("Empty String Field Length", emptyStringField != null ? emptyStringField.Length.ToString() : "null");
 		}
 
 		public void Update()


### PR DESCRIPTION
**Bug:** A `[SerializeField]` field left empty/default in the scene loads as null at runtime for anything that isn't a built-in primitive — an empty `string` becomes null (→ `NullReferenceException` on `.Length`), and a default-valued `struct`/`enum` would load as null too. Bakes clean; NREs at runtime.

**Cause:** `DeserializeDataForProxyField`, for an empty/missing value, returned `Activator.CreateInstance(t)` only when `t.IsPrimitive` and `null` for everything else.

**Fix:** Return the zero instance for any value type, `""` for `string` (the one reference type Unity never serializes as null, and whose `Activator.CreateInstance` throws), and null for every other reference type.
