### PR TITLE
Isolate an unhandled interpreted-script fault to its own behaviour

### DIFF
--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -172,6 +172,8 @@ namespace Cilbox
 
 		public object Interpret( CilboxProxy ths, object [] parametersIn )
 		{
+			if( ths != null && ths.disabled ) return null;
+
 			int plen = parametersIn?.Length ?? 0;
 			int thisOffset = isStatic ? 0 : 1;
 
@@ -200,17 +202,9 @@ namespace Cilbox
 			catch( Exception e )
 			{
 				parentClass.box.InterpreterExit();
-
-				if (e is CilboxUnhandledInterpretedException uhe)
-				{
-					// strip the throwee just in case, and re-throw a normal runtime exception
-					string exceptionTypeName = uhe.Throwee?.GetType().FullName ?? "null";
-					string reason = $"Exception of type {exceptionTypeName} was unhandled in interpreted code";
-					parentClass.box.DisableWithReason(reason); // CilboxUnhandledInterpretedException bypasses the box disable
-					throw new CilboxInterpreterRuntimeException(reason, uhe.ClassName, uhe.MethodName, uhe.PC);
-				}
-
-				Debug.Log( e.ToString() );
+				if( ths != null ) ths.DisableProxy();
+				else parentClass.box.DisableWithReason(e.ToString());
+				if( e is CilboxUnhandledInterpretedException uhe && uhe.Throwee is System.Exception te ) throw te;
 				throw;
 			}
 			parentClass.box.InterpreterExit();
@@ -251,7 +245,6 @@ namespace Cilbox
 			bool cont = true;
 			int pc = 0;
 			CilMetadataTokenInfo constrainedMeta = null;
-			try
 			{
 				do
 				{
@@ -420,16 +413,23 @@ spiperf.Begin();
 									if( !targetMethod.isStatic )
 										stackBuffer[nextParameterStart] = stackBuffer[sp--];
 
-									try
+									if( !targetMethod.isStatic && stackBuffer[nextParameterStart].AsObject() is CilboxProxy dispatchProxy && dispatchProxy.disabled )
 									{
-										if (!isVoid && !ctorAsCall)
-											stackBuffer[++sp] = targetMethod.InterpretInner(stackBufferIn.Slice(nextStackHead), stackBufferIn.Slice(nextParameterStart, numParams + staticOffset));
-										else
-											targetMethod.InterpretInner(stackBufferIn.Slice(nextStackHead), stackBufferIn.Slice(nextParameterStart, numParams + staticOffset));
+										interpretedThrow( currentInstruction, new System.Exception( "Attempted to invoke a method on a disabled interpreted behaviour" ) );
 									}
-									catch (CilboxUnhandledInterpretedException e)
+									else
 									{
-										interpretedThrow(currentInstruction, e.Throwee);
+										try
+										{
+											if (!isVoid && !ctorAsCall)
+												stackBuffer[++sp] = targetMethod.InterpretInner(stackBufferIn.Slice(nextStackHead), stackBufferIn.Slice(nextParameterStart, numParams + staticOffset));
+											else
+												targetMethod.InterpretInner(stackBufferIn.Slice(nextStackHead), stackBufferIn.Slice(nextParameterStart, numParams + staticOffset));
+										}
+										catch (CilboxUnhandledInterpretedException e)
+										{
+											interpretedThrow(currentInstruction, e.Throwee);
+										}
 									}
 								}
 
@@ -1032,6 +1032,12 @@ spiperf.Begin();
 							break;
 						}
 
+						if( opths is CilboxProxy fieldProxy && fieldProxy.disabled )
+						{
+							interpretedThrow( pc - 1, new System.Exception( "Attempted to access a field on a disabled interpreted behaviour" ) );
+							break;
+						}
+
 						if( TryGetInternalObjectData( opths, out _, out StackElement[] internalFields ) )
 						{
 							stackBuffer[++sp] = internalFields[box.metadatas[bc].fieldIndex];
@@ -1063,6 +1069,12 @@ spiperf.Begin();
 							break;
 						}
 
+						if( opths is CilboxProxy fieldProxy && fieldProxy.disabled )
+						{
+							interpretedThrow( pc - 1, new System.Exception( "Attempted to access a field on a disabled interpreted behaviour" ) );
+							break;
+						}
+
 						if( TryGetInternalObjectData( opths, out _, out StackElement[] internalFields ) )
 						{
 							stackBuffer[++sp] = StackElement.CreateAddressReference((Array)(internalFields), (uint)box.metadatas[bc].fieldIndex);
@@ -1080,6 +1092,12 @@ spiperf.Begin();
 						if (opths == null)
 						{
 							interpretedThrow(pc - 1, new NullReferenceException());
+							break;
+						}
+
+						if( opths is CilboxProxy fieldProxy && fieldProxy.disabled )
+						{
+							interpretedThrow( pc - 1, new System.Exception( "Attempted to access a field on a disabled interpreted behaviour" ) );
 							break;
 						}
 
@@ -1670,23 +1688,6 @@ spiperf.End();
 #endif
 				}
 				while( cont );
-			}
-			catch (CilboxUnhandledInterpretedException)
-			{
-				// don't break program flow for interpreted exceptions; we want to pass flow back to the outer call.
-				throw;
-			}
-			catch( Exception e )
-			{
-				string fullError = $"Breakwarn: {e.ToString()} Class: {parentClass.className}, Function: {methodName}, Bytecode: {pc}";
-				box.DisableWithReason(fullError);
-
-				if (e is CilboxInterpreterRuntimeException)
-				{
-					throw;
-				}
-
-				throw new CilboxInterpreterRuntimeException($"Breakwarn: Unhandled exception", e, parentClass.className, methodName, pc);
 			}
 #if UNITY_EDITOR
 			perfMarkerInterpret.End();

--- a/Packages/com.cnlohr.cilbox/CilboxProxy.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxProxy.cs
@@ -26,6 +26,15 @@ namespace Cilbox
 		private bool proxyWasSetup = false;
 		private bool proxyLoadInProgress = false;
 
+		public bool disabled = false;
+
+		public void DisableProxy()
+		{
+			if( disabled ) return;
+			disabled = true;
+			enabled = false;
+		}
+
 		private void ProxyDebugLog( string message )
 		{
 				Debug.Log( $"[CilboxProxy:{gameObject.name}] {message}" );

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -390,6 +390,13 @@ namespace TestCilbox
 			GameObject secInheritsGo = new GameObject("SecInheritsProhibitedToProxy");
 			SecInheritsProhibited secInherits = secInheritsGo.CreateComponent<SecInheritsProhibited>();
 
+			GameObject isoFaultGo = new GameObject("IsolationFaultToProxy");
+			IsolationFaultBehaviour isoFault = isoFaultGo.CreateComponent<IsolationFaultBehaviour>();
+			IsolationSiblingBehaviour isoSibling = isoFaultGo.CreateComponent<IsolationSiblingBehaviour>();
+			GameObject isoSurvivorGo = new GameObject("IsolationSurvivorToProxy");
+			IsolationSurvivorBehaviour isoSurvivor = isoSurvivorGo.CreateComponent<IsolationSurvivorBehaviour>();
+			isoSurvivor.target = isoFault;
+
 			GameObject cbobj = new GameObject("BasicCilbox");
 			Cilbox.Cilbox cb = cbobj.AddComponent<CilboxTester>();
 			cb.exportDebuggingData = true;
@@ -487,6 +494,7 @@ namespace TestCilbox
 			proxy.GetType().GetMethod("FixedUpdate",BindingFlags.Instance|BindingFlags.NonPublic,Type.EmptyTypes).Invoke( proxy, new object[0] );
 			Validator.Validate( "Execution after timeout", "disabled" );
 
+			Validator.Set( "Proxy Disabled After Timeout", proxy.disabled.ToString() );
 			cb.disabled = false;
 			proxy.GetType().GetMethod("FixedUpdate",BindingFlags.Instance|BindingFlags.NonPublic,Type.EmptyTypes).Invoke( proxy, new object[0] );
 
@@ -494,8 +502,8 @@ namespace TestCilbox
 			Validator.Set("Real timeoutLengthUs", cb.timeoutLengthUs.ToString() );
 			Validator.Validate("Real timeoutLengthUs", cb.MaxTimeoutLengthUs.ToString() );
 
-			Validator.Validate( "Manual Recover After Timeout", "recovered" );
-			Validator.Validate( "FixedUpdate", "called" );
+			Validator.Validate( "Proxy Disabled After Timeout", "True" );
+			Validator.Validate( "Execution after timeout", "disabled" );
 
 			Validator.Validate("Dispose", "disposed" );
 			Validator.Validate("TryFinally", "finally");
@@ -813,7 +821,7 @@ namespace TestCilbox
 			Validator.Validate( "Char Trailing Eq", "2" );
 			Validator.Validate( "Char Code A", "65" );
 
-			Validator.ValidateCount($"CilboxDisabled_{cb.GetType().FullName}", 1 );
+			Validator.ValidateCount($"CilboxDisabled_{cb.GetType().FullName}", 0 );
 
 			if( runPerf )
 			{
@@ -835,6 +843,48 @@ namespace TestCilbox
 			Validator.Set("Sec BaseClasses Omits Prohibited Ancestor", (secInheritsCls != null && System.Array.IndexOf(secInheritsCls.baseClassNames, "TestCilbox.SecProhibitedBase") < 0).ToString());
 			Validator.Validate("Sec BaseClasses Has Cilboxable Ancestor", "True");
 			Validator.Validate("Sec BaseClasses Omits Prohibited Ancestor", "True");
+
+			cb.disabled = false;
+			Cilbox.CilboxProxy isoFaultProxy = null;
+			Cilbox.CilboxProxy isoSiblingProxy = null;
+			foreach( Cilbox.CilboxProxy p in isoFaultGo.GetComponents<Cilbox.CilboxProxy>() )
+			{
+				if( p.className.Contains( "IsolationFaultBehaviour" ) ) isoFaultProxy = p;
+				else if( p.className.Contains( "IsolationSiblingBehaviour" ) ) isoSiblingProxy = p;
+			}
+			Cilbox.CilboxProxy isoSurvivorProxy = isoSurvivorGo.GetComponents<Cilbox.CilboxProxy>()[0];
+			isoFaultProxy.RuntimeProxyLoad();
+			isoSiblingProxy.RuntimeProxyLoad();
+			isoSurvivorProxy.RuntimeProxyLoad();
+			Validator.Set( "Isolation Survivor Target Resolved", (GetProxyFieldObject( isoSurvivorProxy, "target" ) != null).ToString() );
+			Validator.Set( "Isolation Fault Post", "skipped" );
+			Validator.Set( "Isolation Sibling Post", "skipped" );
+			try
+			{
+				InvokeProxyMethod( isoFaultProxy, "Start" );
+				Validator.Set( "Isolation Fault Threw", "no" );
+			}
+			catch( TargetInvocationException )
+			{
+				Validator.Set( "Isolation Fault Threw", "yes" );
+			}
+			Validator.Set( "Isolation Fault Proxy Disabled", isoFaultProxy.disabled.ToString() );
+			Validator.Set( "Isolation Sibling Proxy Disabled", isoSiblingProxy.disabled.ToString() );
+			Validator.Set( "Isolation Box Disabled After Fault", cb.disabled.ToString() );
+			InvokeProxyMethod( isoSurvivorProxy, "Update" );
+			InvokeProxyMethod( isoFaultProxy, "Update" );
+			InvokeProxyMethod( isoSiblingProxy, "Update" );
+			Validator.Validate( "Isolation Fault Started", "yes" );
+			Validator.Validate( "Isolation Fault Threw", "yes" );
+			Validator.Validate( "Isolation Fault Proxy Disabled", "True" );
+			Validator.Validate( "Isolation Sibling Proxy Disabled", "False" );
+			Validator.Validate( "Isolation Box Disabled After Fault", "False" );
+			Validator.Validate( "Isolation Survivor Ran", "yes" );
+			Validator.Validate( "Isolation Survivor Target Resolved", "True" );
+			Validator.Validate( "Isolation Fault Post", "skipped" );
+			Validator.Validate( "Isolation Sibling Post", "ran" );
+			Validator.Validate( "Isolation Reach Method", "blocked" );
+			Validator.Validate( "Isolation Reach Field", "blocked" );
 
 			return -1 * Validator.NumValidationErrors();
 		}

--- a/TestCilbox/TestCilboxable.cs
+++ b/TestCilbox/TestCilboxable.cs
@@ -1220,4 +1220,49 @@ namespace TestCilbox
 	{
 		public int derivedTag = 5;
 	}
+
+	[Cilboxable]
+	public class IsolationFaultBehaviour : MonoBehaviour
+	{
+		public int marker = 42;
+		public void Start()
+		{
+			Validator.Set("Isolation Fault Started", "yes");
+			throw new Exception("Injected interpreted fault");
+		}
+		public void Update()
+		{
+			Validator.Set("Isolation Fault Post", "ran");
+		}
+		public int GetMarker()
+		{
+			Validator.Set("Isolation Fault Method Ran", "yes");
+			return marker;
+		}
+	}
+
+	[Cilboxable]
+	public class IsolationSiblingBehaviour : MonoBehaviour
+	{
+		public void Update()
+		{
+			Validator.Set("Isolation Sibling Post", "ran");
+		}
+	}
+
+	[Cilboxable]
+	public class IsolationSurvivorBehaviour : MonoBehaviour
+	{
+		public IsolationFaultBehaviour target;
+		public void Update()
+		{
+			Validator.Set("Isolation Survivor Ran", "yes");
+			{
+				try { Validator.Set("Isolation Reach Method", "reached:" + target.GetMarker()); }
+				catch( Exception ) { Validator.Set("Isolation Reach Method", "blocked"); }
+				try { Validator.Set("Isolation Reach Field", "reached:" + target.marker); }
+				catch( Exception ) { Validator.Set("Isolation Reach Field", "blocked"); }
+			}
+		}
+	}
 }


### PR DESCRIPTION
**Bug:** An unhandled interpreted exception or a script timeout calls `box.DisableWithReason(...)`, disabling the entire Cilbox — every proxy in the scene stops, not just the one that faulted. Bakes/builds clean; fails only at runtime.

**Cause:** The unhandled-exception branch in `Interpret(...)` and the inner-loop `catch` in `InterpretInner(...)` both box-disable, so any one behaviour's fault (or timeout) is fatal to the whole world.

**Fix:** Faults and timeouts now propagate to a single entry `catch` that disables only the offending `CilboxProxy` (`enabled = false` plus a `disabled` flag) and re-throws for Unity to log; a static call with no `this` proxy still box-disables. A disabled proxy is made fully inert — the entry gate skips its lifecycle, and `call`/`ldfld`/`ldflda`/`stfld` against it throw an interpreted fault into the caller — so nothing on it is reachable from other interpreted scripts, while sibling behaviours and the GameObject's native components keep running.