### PR TITLE
Editor: make interpreted-fault stack traces clickable to world source

### DIFF
--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -201,6 +201,7 @@ namespace Cilbox
 
 				if (e is CilboxUnhandledInterpretedException uhe)
 				{
+					CilboxFault.Report( uhe );
 					// strip the throwee just in case, and re-throw a normal runtime exception
 					string exceptionTypeName = uhe.Throwee?.GetType().FullName ?? "null";
 					string reason = $"Exception of type {exceptionTypeName} was unhandled in interpreted code";
@@ -409,7 +410,7 @@ spiperf.Begin();
 									}
 									catch (CilboxUnhandledInterpretedException e)
 									{
-										interpretedThrow(currentInstruction, e.Throwee);
+										interpretedThrow(currentInstruction, e.Throwee, e.Frames);
 									}
 									stackBuffer[++sp].LoadObject( newObj );
 								}
@@ -427,7 +428,7 @@ spiperf.Begin();
 									}
 									catch (CilboxUnhandledInterpretedException e)
 									{
-										interpretedThrow(currentInstruction, e.Throwee);
+										interpretedThrow(currentInstruction, e.Throwee, e.Frames);
 									}
 								}
 
@@ -1761,13 +1762,15 @@ spiperf.End();
 				return newObj;
 			}
 
-			void interpretedThrow(int currentInstruction, object thrownObj)
+			void interpretedThrow(int currentInstruction, object thrownObj, System.Collections.Generic.List<string> priorFrames = null)
 			{
 				sp = -1;
 				exceptionRegister = new StackElement() { type = StackType.Object, o = thrownObj };
+				System.Collections.Generic.List<string> frames = priorFrames != null ? new System.Collections.Generic.List<string>(priorFrames) : new System.Collections.Generic.List<string>();
+				frames.Add(parentClass.className + "|" + methodName + "|" + currentInstruction);
 				if (!hasExceptionClauses)
 				{
-					throw new CilboxUnhandledInterpretedException("Exception thrown with no handlers: " + (thrownObj?.ToString() ?? "(null)"), thrownObj, parentClass.className, methodName, currentInstruction);
+					throw new CilboxUnhandledInterpretedException("Exception thrown with no handlers: " + (thrownObj?.ToString() ?? "(null)"), thrownObj, parentClass.className, methodName, currentInstruction, frames);
 				}
 
 				CilboxExceptionHandlingClause found = null;
@@ -1822,7 +1825,7 @@ spiperf.End();
 
 				if (found == null)
 				{
-					throw new CilboxUnhandledInterpretedException("No handlers matched exception: " + (thrownObj?.ToString() ?? "(null)"), thrownObj, parentClass.className, methodName, currentInstruction);
+					throw new CilboxUnhandledInterpretedException("No handlers matched exception: " + (thrownObj?.ToString() ?? "(null)"), thrownObj, parentClass.className, methodName, currentInstruction, frames);
 				}
 
 				leaveRegionEnqueueFinallys(currentInstruction, found.HandlerOffset, true);

--- a/Packages/com.cnlohr.cilbox/CilboxUtil.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxUtil.cs
@@ -423,11 +423,24 @@ namespace Cilbox
 	public class CilboxUnhandledInterpretedException : CilboxInterpreterRuntimeException
 	{
 		public readonly object Throwee;
+		public readonly System.Collections.Generic.List<string> Frames;
 
-		public CilboxUnhandledInterpretedException(string msg, object throwee, string className, string methodName, int pc) :
+		public CilboxUnhandledInterpretedException(string msg, object throwee, string className, string methodName, int pc, System.Collections.Generic.List<string> frames = null) :
 			base(msg, className, methodName, pc)
 		{
 			Throwee = throwee;
+			Frames = frames;
+		}
+	}
+
+	public static class CilboxFault
+	{
+		public static System.Action< CilboxUnhandledInterpretedException > InterpretedReporter;
+
+		public static void Report( System.Exception e )
+		{
+			if( e is CilboxUnhandledInterpretedException u && InterpretedReporter != null )
+				InterpretedReporter( u );
 		}
 	}
 

--- a/Packages/com.cnlohr.cilbox/Editor.meta
+++ b/Packages/com.cnlohr.cilbox/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 07d5a33688e2d0242889c590ca39842b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.cnlohr.cilbox/Editor/Cilbox.Editor.asmdef
+++ b/Packages/com.cnlohr.cilbox/Editor/Cilbox.Editor.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "Cilbox.Editor",
+    "rootNamespace": "",
+    "references": [
+        "Cilbox"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Packages/com.cnlohr.cilbox/Editor/Cilbox.Editor.asmdef.meta
+++ b/Packages/com.cnlohr.cilbox/Editor/Cilbox.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 78683af12c2e89b4bb0eaaa6b33d4c0d
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.cnlohr.cilbox/Editor/CilboxClickableFaults.cs
+++ b/Packages/com.cnlohr.cilbox/Editor/CilboxClickableFaults.cs
@@ -1,0 +1,36 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using UnityEditor;
+
+namespace Cilbox
+{
+	[InitializeOnLoad]
+	internal static class CilboxClickableFaults
+	{
+		static CilboxClickableFaults()
+		{
+			CilboxFault.InterpretedReporter = Report;
+		}
+
+		static void Report( CilboxUnhandledInterpretedException uhe )
+		{
+			List<CilboxSourceLog.WorldFrame> frames = new List<CilboxSourceLog.WorldFrame>();
+			if( uhe.Frames != null )
+			{
+				foreach( string f in uhe.Frames )
+				{
+					int a = f.IndexOf( '|' );
+					int b = f.LastIndexOf( '|' );
+					if( a <= 0 || b <= a ) continue;
+					if( !int.TryParse( f.Substring( b + 1 ), out int pc ) ) continue;
+					frames.Add( new CilboxSourceLog.WorldFrame( f.Substring( 0, a ), f.Substring( a + 1, b - a - 1 ), pc ) );
+				}
+			}
+
+			string message = uhe.Throwee is Exception thr ? thr.GetType().FullName + ": " + thr.Message : uhe.Message;
+			CilboxSourceLog.LogSourceExceptionLines( message, CilboxSourceLog.ResolveFrameLines( frames ), true );
+		}
+	}
+}
+#endif

--- a/Packages/com.cnlohr.cilbox/Editor/CilboxClickableFaults.cs.meta
+++ b/Packages/com.cnlohr.cilbox/Editor/CilboxClickableFaults.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 51d3f6b614b7da54c8e6f6efe7c714c0

--- a/Packages/com.cnlohr.cilbox/Editor/CilboxSourceLog.cs
+++ b/Packages/com.cnlohr.cilbox/Editor/CilboxSourceLog.cs
@@ -1,0 +1,195 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using UnityEngine;
+
+namespace Cilbox
+{
+	internal static class CilboxSourceLog
+	{
+		class SeqInfo { public string file; public int[] offs; public int[] lines; }
+		static readonly Dictionary<string, SeqInfo> sCache = new Dictionary<string, SeqInfo>();
+		static FieldInfo sRemoteStackField;
+		static bool sTriedRemoteStack;
+
+		internal struct WorldFrame
+		{
+			public string cls;
+			public string method;
+			public int pc;
+			public WorldFrame( string cls, string method, int pc ) { this.cls = cls; this.method = method; this.pc = pc; }
+		}
+
+		[Serializable]
+		internal sealed class CilboxSourceException : Exception
+		{
+			public CilboxSourceException( string message ) : base( message ) { }
+		}
+
+		internal static void LogSourceException( string message, IList<WorldFrame> frames )
+		{
+			LogSourceExceptionLines( message, BuildWorldFrameLines( frames ) );
+		}
+
+		internal static void LogSourceExceptionLines( string message, IList<string> frameLines, bool suppressCallStack = false )
+		{
+			CilboxSourceException ex = new CilboxSourceException( message );
+			if( frameLines != null && frameLines.Count > 0 )
+				SetRemoteStack( ex, string.Join( "\n", frameLines ) + "\n" );
+
+			if( !suppressCallStack )
+			{
+				Debug.LogException( ex );
+				return;
+			}
+
+			StackTraceLogType prev = Application.GetStackTraceLogType( LogType.Exception );
+			Application.SetStackTraceLogType( LogType.Exception, StackTraceLogType.None );
+			try { Debug.LogException( ex ); }
+			finally { Application.SetStackTraceLogType( LogType.Exception, prev ); }
+		}
+
+		internal static void SetWorldStack( Exception ex, IList<WorldFrame> frames )
+		{
+			List<string> lines = BuildWorldFrameLines( frames );
+			if( lines.Count > 0 )
+				SetRemoteStack( ex, string.Join( "\n", lines ) + "\n" );
+		}
+
+		internal static List<string> ResolveFrameLines( IList<WorldFrame> frames )
+		{
+			return BuildWorldFrameLines( frames );
+		}
+
+		internal static string FrameLineForType( string typeFullName, string projectRelativeFile, int line )
+		{
+			int dot = typeFullName.LastIndexOf( '.' );
+			string simple = dot >= 0 ? typeFullName.Substring( dot + 1 ) : typeFullName;
+			return typeFullName + "." + simple + " () (at " + projectRelativeFile + ":" + line + ")";
+		}
+
+		static List<string> BuildWorldFrameLines( IList<WorldFrame> frames )
+		{
+			List<string> lines = new List<string>();
+			if( frames == null ) return lines;
+			foreach( WorldFrame f in frames )
+			{
+				if( TryResolve( f.cls, f.method, f.pc, out string file, out int line ) )
+					lines.Add( f.cls + "." + f.method + " () (at " + ToProjectRelative( file ) + ":" + line + ")" );
+				else
+					lines.Add( f.cls + "." + f.method + " ()" );
+			}
+			return lines;
+		}
+
+		static void SetRemoteStack( Exception ex, string stack )
+		{
+			if( !sTriedRemoteStack )
+			{
+				sTriedRemoteStack = true;
+				sRemoteStackField = typeof( Exception ).GetField( "_remoteStackTraceString", BindingFlags.NonPublic | BindingFlags.Instance );
+			}
+			if( sRemoteStackField != null )
+				sRemoteStackField.SetValue( ex, stack );
+		}
+
+		static string ToProjectRelative( string file )
+		{
+			string rel = file.Replace( '\\', '/' );
+			string dataPath = Application.dataPath.Replace( '\\', '/' );
+			if( rel.StartsWith( dataPath ) ) rel = "Assets" + rel.Substring( dataPath.Length );
+			return rel;
+		}
+
+		static bool TryResolve( string className, string methodName, int pc, out string file, out int line )
+		{
+			file = null; line = 0;
+			if( string.IsNullOrEmpty( className ) || string.IsNullOrEmpty( methodName ) ) return false;
+			Type type = FindType( className );
+			if( type == null ) return false;
+			string dll = type.Assembly.Location;
+			if( string.IsNullOrEmpty( dll ) || !File.Exists( dll ) ) return false;
+
+			string key = dll + "|" + className + "|" + methodName;
+			SeqInfo info;
+			if( !sCache.TryGetValue( key, out info ) )
+			{
+				info = ReadSeqPoints( dll, className, methodName );
+				sCache[key] = info;
+			}
+			if( info == null || info.offs == null || info.offs.Length == 0 ) return false;
+
+			int bestOff = -1;
+			for( int i = 0; i < info.offs.Length; i++ )
+				if( info.offs[i] <= pc && info.offs[i] > bestOff ) { bestOff = info.offs[i]; line = info.lines[i]; }
+			if( bestOff < 0 ) return false;
+			file = info.file;
+			return true;
+		}
+
+		static Type FindType( string fullName )
+		{
+			foreach( Assembly a in AppDomain.CurrentDomain.GetAssemblies() )
+			{
+				try { Type t = a.GetType( fullName ); if( t != null ) return t; } catch { }
+			}
+			return null;
+		}
+
+		static SeqInfo ReadSeqPoints( string dll, string className, string methodName )
+		{
+			string pdb = Path.ChangeExtension( dll, ".pdb" );
+			if( !File.Exists( pdb ) ) return null;
+			Assembly cecil = null;
+			foreach( Assembly a in AppDomain.CurrentDomain.GetAssemblies() )
+				if( a.GetType( "Mono.Cecil.AssemblyDefinition" ) != null ) { cecil = a; break; }
+			if( cecil == null ) return null;
+			try
+			{
+				Type tAsm = cecil.GetType( "Mono.Cecil.AssemblyDefinition" );
+				Type tRP = cecil.GetType( "Mono.Cecil.ReaderParameters" );
+				object rp = Activator.CreateInstance( tRP );
+				tRP.GetProperty( "ReadSymbols" ).SetValue( rp, true );
+				MethodInfo read = tAsm.GetMethod( "ReadAssembly", new Type[] { typeof( string ), tRP } );
+				object asm = read.Invoke( null, new object[] { dll, rp } );
+				using( (IDisposable)asm )
+				{
+					object module = tAsm.GetProperty( "MainModule" ).GetValue( asm );
+					MethodInfo getType = module.GetType().GetMethod( "GetType", new Type[] { typeof( string ) } );
+					object td = getType.Invoke( module, new object[] { className } );
+					if( td == null ) return null;
+					IEnumerable methods = (IEnumerable)td.GetType().GetProperty( "Methods" ).GetValue( td );
+					foreach( object md in methods )
+					{
+						if( (string)md.GetType().GetProperty( "Name" ).GetValue( md ) != methodName ) continue;
+						object di = md.GetType().GetProperty( "DebugInformation" ).GetValue( md );
+						if( di == null ) continue;
+						if( !(bool)di.GetType().GetProperty( "HasSequencePoints" ).GetValue( di ) ) continue;
+						IEnumerable sps = (IEnumerable)di.GetType().GetProperty( "SequencePoints" ).GetValue( di );
+						List<int> offs = new List<int>();
+						List<int> lines = new List<int>();
+						string file = null;
+						foreach( object sp in sps )
+						{
+							if( (bool)sp.GetType().GetProperty( "IsHidden" ).GetValue( sp ) ) continue;
+							int off = (int)sp.GetType().GetProperty( "Offset" ).GetValue( sp );
+							int ln = (int)sp.GetType().GetProperty( "StartLine" ).GetValue( sp );
+							object doc = sp.GetType().GetProperty( "Document" ).GetValue( sp );
+							if( file == null ) file = (string)doc.GetType().GetProperty( "Url" ).GetValue( doc );
+							offs.Add( off ); lines.Add( ln );
+						}
+						SeqInfo si = new SeqInfo();
+						si.file = file; si.offs = offs.ToArray(); si.lines = lines.ToArray();
+						return si;
+					}
+				}
+			}
+			catch { }
+			return null;
+		}
+	}
+}
+#endif

--- a/Packages/com.cnlohr.cilbox/Editor/CilboxSourceLog.cs.meta
+++ b/Packages/com.cnlohr.cilbox/Editor/CilboxSourceLog.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4bd71d235c6910f4bbb01dc62fb3ba94

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -381,6 +381,9 @@ namespace TestCilbox
 				perfRoot.peer = perfPeer;
 			}
 
+			GameObject frameFaultGo = new GameObject("FrameFaultToProxy");
+			FrameFaultBehaviour frameFault = frameFaultGo.CreateComponent<FrameFaultBehaviour>();
+
 			GameObject cbobj = new GameObject("BasicCilbox");
 			Cilbox.Cilbox cb = cbobj.AddComponent<CilboxTester>();
 			cb.exportDebuggingData = true;
@@ -813,6 +816,28 @@ namespace TestCilbox
 			Validator.Validate( "Empty String Field Length", "0" );
 
 			Validator.Validate( "StargClamp", "210" );
+
+			Cilbox.CilboxProxy frameFaultProxy = frameFaultGo.GetComponents<Cilbox.CilboxProxy>()[0];
+			frameFaultProxy.RuntimeProxyLoad();
+			List<string> capturedFrames = null;
+			Cilbox.CilboxFault.InterpretedReporter = uhe => { capturedFrames = uhe.Frames; };
+			try { InvokeProxyMethod( frameFaultProxy, "Start" ); }
+			catch( TargetInvocationException ) { }
+			Cilbox.CilboxFault.InterpretedReporter = null;
+			string frameOrder = "";
+			if( capturedFrames != null )
+			{
+				foreach( string f in capturedFrames )
+				{
+					string[] parts = f.Split('|');
+					if( frameOrder.Length > 0 ) frameOrder += ">";
+					frameOrder += parts.Length > 1 ? parts[1] : f;
+				}
+			}
+			Validator.Set( "Frames Count", capturedFrames != null ? capturedFrames.Count.ToString() : "null" );
+			Validator.Set( "Frames Order", frameOrder );
+			Validator.Validate( "Frames Count", "3" );
+			Validator.Validate( "Frames Order", "Level2>Level1>Start" );
 
 			return -1 * Validator.NumValidationErrors();
 		}

--- a/TestCilbox/TestCilboxable.cs
+++ b/TestCilbox/TestCilboxable.cs
@@ -1168,4 +1168,21 @@ namespace TestCilbox
 			return PerfUtility.StopwatchToUs(sw);
 		}
 	}
+	[Cilboxable]
+	public class FrameFaultBehaviour : MonoBehaviour
+	{
+		public void Start()
+		{
+			Level1();
+		}
+		public void Level1()
+		{
+			Level2();
+		}
+		public void Level2()
+		{
+			throw new Exception("deep interpreted fault");
+		}
+	}
+
 }


### PR DESCRIPTION
**Bug:** When an interpreted script throws an exception no world handler catches, the Unity console entry points into the interpreter (`Interpret`/`InterpretInner`) instead of the world script, with no clickable path to the offending source line.

**Cause:** `CilboxUnhandledInterpretedException` recorded only the throw site's `class`/`method`/`pc`, so the interpreted call chain that led to the fault was gone by the time it surfaced.

**Fix:** `interpretedThrow(...)` now appends a `className|method|pc` frame per level as the exception unwinds and hangs the list on the exception. At the top-level catch `CilboxFault` dispatches the frames to an editor-only reporter that resolves each to its world source line via `CilboxSourceLog` and logs a clickable, world-only stack trace; no effect in player builds.

**Related:** Uses the shared source-mapping logger from #107 and stacks on it.