### PR TITLE
Forward LateUpdate/OnTriggerStay/OnCollisionStay/OnRenderObject/OnWillRenderObject to interpreted scripts

### DIFF
--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -3200,6 +3200,11 @@ spiperf.End();
 		OnTriggerEnter,
 		OnTriggerExit,
 		OnCollisionEnter,
-		OnCollisionExit
+		OnCollisionExit,
+		LateUpdate,
+		OnTriggerStay,
+		OnCollisionStay,
+		OnRenderObject,
+		OnWillRenderObject
 	}
 }

--- a/Packages/com.cnlohr.cilbox/CilboxProxy.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxProxy.cs
@@ -513,6 +513,7 @@ namespace Cilbox
 		}
 		void FixedUpdate() { if( proxyWasSetup ) box.InterpretIID( cls, this, ImportFunctionID.FixedUpdate, null ); }
 		void Update() { if( proxyWasSetup ) box.InterpretIID( cls, this, ImportFunctionID.Update, null ); }
+		void LateUpdate() { if( proxyWasSetup ) box.InterpretIID( cls, this, ImportFunctionID.LateUpdate, null ); }
 		void OnEnable() { if( proxyWasSetup ) box.InterpretIID( cls, this, ImportFunctionID.OnEnable, null ); }
 		void OnDisable() { if( proxyWasSetup ) box.InterpretIID( cls, this, ImportFunctionID.OnDisable, null ); }
 		void OnDestroy() { if( proxyWasSetup ) box.InterpretIID( cls, this, ImportFunctionID.OnDestroy, null ); }
@@ -520,6 +521,10 @@ namespace Cilbox
 		void OnTriggerExit(Collider c) { if (proxyWasSetup) box.InterpretIID(cls, this, ImportFunctionID.OnTriggerExit, new object[] { c }); }
 		void OnCollisionEnter(Collision c) { if (proxyWasSetup) box.InterpretIID(cls, this, ImportFunctionID.OnCollisionEnter, new object[] { c }); }
 		void OnCollisionExit(Collision c) { if (proxyWasSetup) box.InterpretIID(cls, this, ImportFunctionID.OnCollisionExit, new object[] { c }); }
+		void OnTriggerStay(Collider c) { if (proxyWasSetup) box.InterpretIID(cls, this, ImportFunctionID.OnTriggerStay, new object[] { c }); }
+		void OnCollisionStay(Collision c) { if (proxyWasSetup) box.InterpretIID(cls, this, ImportFunctionID.OnCollisionStay, new object[] { c }); }
+		void OnRenderObject() { if (proxyWasSetup) box.InterpretIID(cls, this, ImportFunctionID.OnRenderObject, null); }
+		void OnWillRenderObject() { if (proxyWasSetup) box.InterpretIID(cls, this, ImportFunctionID.OnWillRenderObject, null); }
 	}
 }
 

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -430,6 +430,13 @@ namespace TestCilbox
 				Validator.Validate( "string concatenation", "it works" );
 				Validator.Validate( "MathF.Sin", "-0.058374193" );
 
+				proxy.GetType().GetMethod("LateUpdate",BindingFlags.Instance|BindingFlags.NonPublic,Type.EmptyTypes).Invoke( proxy, new object[0] );
+				Validator.Validate( "LateUpdate", "called" );
+				proxy.GetType().GetMethod("OnRenderObject",BindingFlags.Instance|BindingFlags.NonPublic,Type.EmptyTypes).Invoke( proxy, new object[0] );
+				Validator.Validate( "OnRenderObject", "called" );
+				proxy.GetType().GetMethod("OnWillRenderObject",BindingFlags.Instance|BindingFlags.NonPublic,Type.EmptyTypes).Invoke( proxy, new object[0] );
+				Validator.Validate( "OnWillRenderObject", "called" );
+
 				// Make sure CI can fail.
 				//Validator.Validate( "Test Fail Check", "This will fail" );
 			}

--- a/TestCilbox/TestCilboxable.cs
+++ b/TestCilbox/TestCilboxable.cs
@@ -618,6 +618,24 @@ namespace TestCilbox
 			Validator.Set( "Overtime", "did not timed out" );
 		}
 
+		// Lifecycle forwarders added by CilboxProxy: LateUpdate/OnRenderObject/OnWillRenderObject are
+		// mapped to the interpreter by name via the ImportFunctionID enum, so invoking the proxy's
+		// matching Unity callback must reach these payload methods.
+		public void LateUpdate()
+		{
+			Validator.Set( "LateUpdate", "called" );
+		}
+
+		public void OnRenderObject()
+		{
+			Validator.Set( "OnRenderObject", "called" );
+		}
+
+		public void OnWillRenderObject()
+		{
+			Validator.Set( "OnWillRenderObject", "called" );
+		}
+
 
 		public void FixedUpdate()
 		{


### PR DESCRIPTION
**Bug:** Interpreted `[Cilboxable]` scripts never receive the `LateUpdate`, `OnTriggerStay`, `OnCollisionStay`, `OnRenderObject`, or `OnWillRenderObject` callbacks, so scripts relying on these events silently do nothing.

**Cause:** `CilboxProxy` forwards only a subset of lifecycle events, and these five had neither a proxy forwarder nor an `ImportFunctionID` entry, so the bake's name-based event mapping dropped them.

**Fix:** Add the five proxy forwarders and the matching `ImportFunctionID` members; because events map by name at bake time, no bake change is needed.
