### PR TITLE
Support native value-type constructors invoked in-place (ldloca; call .ctor)

### DIFF
--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -490,23 +490,39 @@ spiperf.Begin();
 								else
 								{
 									StackElement ctorThisSe = stackBuffer[sp--];
-									object ctorThis = ctorThisSe.AsObject(box);
-									if (ctorThis == null)
-									{
-										interpretedThrow(pc - 1, new NullReferenceException());
-										break;
-									}
-
 									Type ctorDeclaringType = ctor.DeclaringType;
-									if( ctorDeclaringType == null || ( ctorDeclaringType != typeof(object) && ctorDeclaringType != typeof(MonoBehaviour) ) )
-									{
-										throw new CilboxInterpreterRuntimeException(
-											$"Unsupported native constructor call on existing instance: {ctor.DeclaringType?.FullName}",
-											parentClass.className, methodName, pc);
-									}
 
-									// Base constructors for Object/MonoBehaviour are no-ops in interpreter mode.
-									isVoid = true;
+									if( ctorDeclaringType != null && ctorDeclaringType.IsValueType )
+									{
+										object newStruct = ctor.Invoke( callpar );
+										if( ctorThisSe.type == StackType.Address )
+											ctorThisSe.DereferenceLoadAddress( newStruct );
+										else if( ctorThisSe.type == StackType.NativeHandle )
+											ctorThisSe.DereferenceLoadNativeHandle( box, newStruct );
+										else
+											throw new CilboxInterpreterRuntimeException(
+												$"Unsupported target for native value-type constructor: {ctorDeclaringType.FullName}",
+												parentClass.className, methodName, pc);
+										isVoid = true;
+									}
+									else
+									{
+										object ctorThis = ctorThisSe.AsObject(box);
+										if (ctorThis == null)
+										{
+											interpretedThrow(pc - 1, new NullReferenceException());
+											break;
+										}
+
+										if( ctorDeclaringType == null || ( ctorDeclaringType != typeof(object) && ctorDeclaringType != typeof(MonoBehaviour) ) )
+										{
+											throw new CilboxInterpreterRuntimeException(
+												$"Unsupported native constructor call on existing instance: {ctorDeclaringType?.FullName}",
+												parentClass.className, methodName, pc);
+										}
+
+										isVoid = true;
+									}
 								}
 							}
 							else if( !st.IsStatic )

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -84,12 +84,17 @@ namespace TestCilbox
 			"UnityEngine.Transform",
 			"UnityEngine.Vector4",
 			"UnityEngine.Vector3",
+			"UnityEngine.Quaternion",
 		};
 
 		static HashSet<String> whiteListField = new HashSet<String>(){
 			"UnityEngine.Vector3.x",
 			"UnityEngine.Vector3.y",
 			"UnityEngine.Vector3.z",
+			"UnityEngine.Quaternion.x",
+			"UnityEngine.Quaternion.y",
+			"UnityEngine.Quaternion.z",
+			"UnityEngine.Quaternion.w",
 			"TestCilbox.TestUtil.StaticFloat",
 		};
 
@@ -759,6 +764,12 @@ namespace TestCilbox
 			Validator.Validate("ThrowFromOtherBehaviour2", "caught");
 			Validator.Validate("ThrowFromOtherBehaviour2Finally", "finally");
 			Validator.Validate("ThrowFromOtherConstructor", "caught");
+
+			Validator.Validate( "NativeStructCtor Vector2", "<3.5, 4.5>" );
+			Validator.Validate( "NativeStructCtor Quaternion x", "0.5" );
+			Validator.Validate( "NativeStructCtor Quaternion y", "0.25" );
+			Validator.Validate( "NativeStructCtor Quaternion z", "0.75" );
+			Validator.Validate( "NativeStructCtor Quaternion w", "1" );
 
 			Validator.ValidateCount($"CilboxDisabled_{cb.GetType().FullName}", 1 );
 

--- a/TestCilbox/TestCilboxable.cs
+++ b/TestCilbox/TestCilboxable.cs
@@ -565,6 +565,17 @@ namespace TestCilbox
 			Validator.Set("PrivateComplexOutAlreadyInitLives", complexOutAlreadyInit.Payload.Lives.ToString() );
 			Validator.Set("PrivateComplexOutAlreadyInitPeer", complexOutAlreadyInit.Peer.pubsettee.ToString() );
 
+			System.Numerics.Vector2 nativeCtorVec = new System.Numerics.Vector2(1.5f, 2.5f);
+			nativeCtorVec = new System.Numerics.Vector2(3.5f, 4.5f);
+			Validator.Set( "NativeStructCtor Vector2", nativeCtorVec.ToString() );
+
+			Quaternion nativeCtorQuat = Quaternion.identity;
+			nativeCtorQuat = new Quaternion(0.5f, 0.25f, 0.75f, 1.0f);
+			Validator.Set( "NativeStructCtor Quaternion x", nativeCtorQuat.x.ToString() );
+			Validator.Set( "NativeStructCtor Quaternion y", nativeCtorQuat.y.ToString() );
+			Validator.Set( "NativeStructCtor Quaternion z", nativeCtorQuat.z.ToString() );
+			Validator.Set( "NativeStructCtor Quaternion w", nativeCtorQuat.w.ToString() );
+
 			behaviour2.Behaviour2Test();
 			myBehaviour3Arr = new TestCilboxBehaviour3[] { new TestCilboxBehaviour3(123), new TestCilboxBehaviour3(456)};
 			Validator.Set("myBehaviour3Arr Length", myBehaviour3Arr.Length.ToString());

--- a/TestCilbox/UnityEngine.cs
+++ b/TestCilbox/UnityEngine.cs
@@ -198,6 +198,18 @@ namespace UnityEngine
 		}
 	}
 
+	public struct Quaternion
+	{
+		public float x, y, z, w;
+		public Quaternion( float x, float y, float z, float w ) { this.x = x; this.y = y; this.z = z; this.w = w; }
+		public static Quaternion identity => new Quaternion( 0, 0, 0, 1 );
+
+		public override string ToString()
+		{
+			return $"({x}, {y}, {z}, {w})";
+		}
+	}
+
 	public static class Random
 	{
 		static public int Range( int mi, int ma )


### PR DESCRIPTION
**Bug:** Constructing a native value type in place — e.g. `new Quaternion(...)` assigned to a local/field written more than once — crashes the interpreter with `Unsupported native constructor call on existing instance`. Bakes clean; faults only when the constructor call fires.

**Cause:** When the target storage is addressable and multiply-written, the compiler emits `ldloca`/`ldflda` + `call instance .ctor` instead of `newobj`, and the interpreter's non-`newobj` constructor branch only handled the `object`/`MonoBehaviour` base constructors and threw for native structs (`Quaternion`, `Vector2/3/4`, `Color`, ...).

**Fix:** In that branch, when the constructor's declaring type is a value type, build it via `ctor.Invoke` and store the result back through the managed pointer on the stack (`Address` → `DereferenceLoadAddress`, `NativeHandle` → `DereferenceLoadNativeHandle`); base-constructor behavior is unchanged.

**Related:** #100, #91
