### PR TITLE
Push native char returns as a numeric stack type, not a boxed object

### DIFF
--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -575,7 +575,10 @@ spiperf.Begin();
 
 							if( !isVoid )
 							{
-								stackBuffer[++sp].Load( iko );
+								if( iko is char retChar )
+									stackBuffer[++sp].LoadUshort( (ushort)retChar );
+								else
+									stackBuffer[++sp].Load( iko );
 							}
 							if( isJmp )
 							{

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -760,6 +760,9 @@ namespace TestCilbox
 			Validator.Validate("ThrowFromOtherBehaviour2Finally", "finally");
 			Validator.Validate("ThrowFromOtherConstructor", "caught");
 
+			Validator.Validate( "Char Trailing Eq", "2" );
+			Validator.Validate( "Char Code A", "65" );
+
 			Validator.ValidateCount($"CilboxDisabled_{cb.GetType().FullName}", 1 );
 
 			if( runPerf )

--- a/TestCilbox/TestCilboxable.cs
+++ b/TestCilbox/TestCilboxable.cs
@@ -565,6 +565,12 @@ namespace TestCilbox
 			Validator.Set("PrivateComplexOutAlreadyInitLives", complexOutAlreadyInit.Payload.Lives.ToString() );
 			Validator.Set("PrivateComplexOutAlreadyInitPeer", complexOutAlreadyInit.Peer.pubsettee.ToString() );
 
+			string trailStr = "ab==";
+			int trailingEq = 0;
+			for( int ci = trailStr.Length - 1; ci >= 0 && trailStr[ci] == '='; ci-- ) trailingEq++;
+			Validator.Set( "Char Trailing Eq", trailingEq.ToString() );
+			Validator.Set( "Char Code A", ((int)"A"[0]).ToString() );
+
 			behaviour2.Behaviour2Test();
 			myBehaviour3Arr = new TestCilboxBehaviour3[] { new TestCilboxBehaviour3(123), new TestCilboxBehaviour3(456)};
 			Validator.Set("myBehaviour3Arr Length", myBehaviour3Arr.Length.ToString());


### PR DESCRIPTION
**Bug:** A native call that returns `char` (e.g. `String.get_Chars`, i.e. `s[i]`) breaks the following numeric/comparison op with `Invalid stack conversion from Object to Int`, so an expression like `s[i] == '='` faults at runtime.

**Cause:** The native-call return path pushed the value with `StackElement.Load`, which boxes a `char` as `StackType.Object`, but `char` is a numeric value type and the following op expected an integer stack element.

**Fix:** Push `char` returns via `LoadUshort((ushort)retChar)` so the value promotes and compares as an integer, matching native `char` semantics; reference-type returns are unaffected.

**Related:** #100
