### PR TITLE
Typed Structs for Serialization/Deserialization

### DIFF
--- a/Assets/CilboxAvatar.cs
+++ b/Assets/CilboxAvatar.cs
@@ -91,7 +91,7 @@ namespace Cilbox
 		}
 
 		// After a type is allowed, this is called to see if the specific method is OK.
-		override public bool CheckMethodAllowed( out MethodInfo mi, Type declaringType, String name, Serializee [] parametersIn, Serializee [] genericArgumentsIn, String fullSignature )
+		override public bool CheckMethodAllowed( out MethodInfo mi, Type declaringType, String name, SerializedTypeDescriptor [] parametersIn, SerializedTypeDescriptor [] genericArgumentsIn, String fullSignature )
 		{
 			mi = null;
 

--- a/Assets/CilboxScene.cs
+++ b/Assets/CilboxScene.cs
@@ -99,7 +99,7 @@ namespace Cilbox
 		}
 
 		// After a type is allowed, this is called to see if the specific method is OK.
-		override public bool CheckMethodAllowed( out MethodInfo mi, Type declaringType, String name, Serializee [] parametersIn, Serializee [] genericArgumentsIn, String fullSignature )
+		override public bool CheckMethodAllowed( out MethodInfo mi, Type declaringType, String name, SerializedTypeDescriptor [] parametersIn, SerializedTypeDescriptor [] genericArgumentsIn, String fullSignature )
 		{
 			mi = null;
 

--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -69,77 +69,56 @@ namespace Cilbox
 		ProfilerMarker perfMarkerInterpret;
 #endif
 
-		public void Load( CilboxClass cclass, String name, Serializee payload )
+		public void Load( CilboxClass cclass, String name, SerializedMethod sm )
 		{
 			methodName = name;
 			parentClass = cclass;
-			Dictionary<String, Serializee> methodProps = payload.AsMap();
-			if( methodProps.TryGetValue( "name", out Serializee methodNameSer ) )
-				methodName = methodNameSer.AsString();
 
-			Serializee [] vl = methodProps["locals"].AsArray();
-			methodLocals = new String[vl.Length];
-			typeLocals = new Type[vl.Length];
-			int iid = 0;
-			for( int i = 0; i < vl.Length; i++ )
+			methodLocals = new String[sm.locals.Length];
+			typeLocals = new Type[sm.locals.Length];
+			for( int i = 0; i < sm.locals.Length; i++ )
 			{
-				Dictionary< String, Serializee > local = vl[i].AsMap();
-				methodLocals[iid] = local["name"].AsString();
-				typeLocals[iid] = parentClass.box.usage.GetNativeTypeFromSerializee( local["dt"] );
-				iid++;
+				methodLocals[i] = sm.locals[i].name;
+				typeLocals[i] = parentClass.box.usage.GetNativeTypeFromDescriptor( sm.locals[i].type );
 			}
 
-			byteCode = methodProps["body"].AsBlob();
+			byteCode = sm.body;
+			MaxStackSize = sm.maxStack;
+			isVoid = sm.isVoid;
+			isStatic = sm.isStatic;
+			fullSignature = sm.fullSignature;
+			isConstructor = sm.isCtor;
 
-			MaxStackSize = Convert.ToInt32((methodProps["maxStack"].AsString()));
-			isVoid = Convert.ToInt32((methodProps["isVoid"].AsString())) != 0;
-			isStatic = Convert.ToInt32((methodProps["isStatic"].AsString())) != 0;
-			fullSignature = methodProps["fullSignature"].AsString();
-			if( methodProps.TryGetValue("isCtor", out Serializee isCtorSer) )
+			signatureParameters = new String[sm.parameters.Length];
+			typeParameters = new Type[sm.parameters.Length];
+			for( int p = 0; p < sm.parameters.Length; p++ )
 			{
-				isConstructor = Convert.ToInt32(isCtorSer.AsString()) != 0;
-			}
-			else
-			{
-				// Backward compatibility for payloads generated before isCtor existed.
-				isConstructor = methodName == ".ctor" || methodName == ".cctor" || fullSignature.StartsWith("Void .ctor(") || fullSignature.StartsWith("Void .cctor(");
-			}
-
-			Serializee [] od = methodProps["parameters"].AsArray();
-			signatureParameters = new String[od.Length];
-			typeParameters = new Type[od.Length];
-			int sn = 0;
-			for( int p = 0; p < od.Length; p ++ )
-			{
-				Dictionary< String, Serializee > thisp = od[p].AsMap();
-				signatureParameters[sn] = thisp["name"].AsString();
-				typeParameters[sn] = parentClass.box.usage.GetNativeTypeFromSerializee( thisp["dt"] );
-				sn++;
+				signatureParameters[p] = sm.parameters[p].name;
+				typeParameters[p] = parentClass.box.usage.GetNativeTypeFromDescriptor( sm.parameters[p].type );
 			}
 
-			if (methodProps.TryGetValue("eh", out Serializee ehArray))
+			if( sm.exceptionHandlers.Length > 0 )
 			{
-				Serializee[] ehc = ehArray.AsArray();
-				exceptionClauses = new CilboxExceptionHandlingClause[ehc.Length];
+				exceptionClauses = new CilboxExceptionHandlingClause[sm.exceptionHandlers.Length];
 				handlerOffsetToClauseMap = new Dictionary<int, CilboxExceptionHandlingClause>();
-				for (int e = 0; e < ehc.Length; e++)
+				for( int e = 0; e < sm.exceptionHandlers.Length; e++ )
 				{
-					Dictionary< String, Serializee > thisehc = ehc[e].AsMap();
+					SerializedExceptionHandler seh = sm.exceptionHandlers[e];
 					CilboxExceptionHandlingClause clause = new CilboxExceptionHandlingClause();
-					clause.Flags = (ExceptionHandlingClauseOptions)Convert.ToInt32(thisehc["flags"].AsString());
-					clause.TryOffset = Convert.ToInt32(thisehc["tryOff"].AsString());
-					clause.TryLength = Convert.ToInt32(thisehc["tryLen"].AsString());
+					clause.Flags = (ExceptionHandlingClauseOptions)seh.flags;
+					clause.TryOffset = seh.tryOffset;
+					clause.TryLength = seh.tryLength;
 					clause.TryEndOffset = clause.TryOffset + clause.TryLength;
-					clause.HandlerOffset = Convert.ToInt32(thisehc["hOff"].AsString());
-					clause.HandlerLength = Convert.ToInt32(thisehc["hLen"].AsString());
+					clause.HandlerOffset = seh.handlerOffset;
+					clause.HandlerLength = seh.handlerLength;
 					clause.HandlerEndOffset = clause.HandlerOffset + clause.HandlerLength;
-					if (thisehc.ContainsKey("cType"))
+					if( seh.hasCatchType )
 					{
-						clause.CatchType = parentClass.box.usage.GetNativeTypeFromSerializee(thisehc["cType"]);
+						clause.CatchType = parentClass.box.usage.GetNativeTypeFromDescriptor( seh.catchType );
 						if (clause.CatchType == null)
 						{
 							// Check if it's a Cilboxable type
-							String typeName = thisehc["cType"].AsMap()["n"].AsString();
+							String typeName = seh.catchType.typeName;
 							if (parentClass.box.classes.ContainsKey(typeName))
 							{
 								clause.CatchTypeName = typeName;
@@ -1960,66 +1939,49 @@ spiperf.End();
 
 		public uint [] importFunctionToId; // from ImportFunctionID
 
-		public String [] baseClassNames = new String[0];
+		public String [] baseClassNames;
 
-		public bool LoadCilboxClass( Cilbox box, String className, Serializee classData )
+		public bool LoadCilboxClass( Cilbox box, String className, SerializedClass sc )
 		{
 			this.box = box;
 			this.className = className;
-
-			Dictionary<String, Serializee> classProps = classData.AsMap();
-
-			if( classProps.TryGetValue( "baseClasses", out Serializee baseClassesSer ) )
-			{
-				// deserialize the cilboxable base-class name list (for polymorphic GetComponent<Base> matching)
-				Serializee [] bcArr = baseClassesSer.AsArray();
-				baseClassNames = new String[bcArr.Length];
-				for( int bci = 0; bci < bcArr.Length; bci++ )
-					baseClassNames[bci] = bcArr[bci].AsString();
-			}
+			this.baseClassNames = sc.baseClassNames;
 
 			uint id = 0;
-			Serializee [] staticFields = classProps["staticFields"].AsArray();
-			int sfnum = staticFields.Length;
+			int sfnum = sc.staticFields.Length;
 			this.staticFields = new object[sfnum];
 			staticFieldNames = new String[sfnum];
 			staticFieldTypes = new Type[sfnum];
 			for( int k = 0; k < sfnum; k++ )
 			{
-				Dictionary< String, Serializee > field = staticFields[k].AsMap();
-				String fieldName = staticFieldNames[id] = field["name"].AsString();
-				Type t = staticFieldTypes[id] = box.usage.GetNativeTypeFromSerializee( field["type"] );
-
-				//staticFieldIDs[id] = Cilbox.FindInternalMetadataID( className, 4, fieldName );
+				String fieldName = staticFieldNames[id] = sc.staticFields[k].name;
+				Type t = staticFieldTypes[id] = box.usage.GetNativeTypeFromDescriptor( sc.staticFields[k].type );
 				this.staticFields[id] = CilboxUtil.DeserializeDataForProxyField( t, "" );
 				id++;
 			}
 
-			Serializee [] instanceFields = classProps["instanceFields"].AsArray();
-			int ifnum = instanceFields.Length;
+			int ifnum = sc.instanceFields.Length;
 			instanceFieldNames = new String[ifnum];
 			instanceFieldTypes = new Type[ifnum];
 
 			id = 0;
 			for( int k = 0; k < ifnum; k++ )
 			{
-				Dictionary< String, Serializee > field = instanceFields[k].AsMap();
-				String fieldName = instanceFieldNames[id] = field["name"].AsString();
-				instanceFieldTypes[id] = box.usage.GetNativeTypeFromSerializee( field["type"] );
+				String fieldName = instanceFieldNames[id] = sc.instanceFields[k].name;
+				instanceFieldTypes[id] = box.usage.GetNativeTypeFromDescriptor( sc.instanceFields[k].type );
 				id++;
 			}
 
 			id = 0;
-			Dictionary< String, Serializee > deserMethods = classProps["methods"].AsMap();
-			int mnum = deserMethods.Count;
+			int mnum = sc.methods.Length;
 			methods = new CilboxMethod[mnum];
 			methodNameToIndex = new Dictionary< String, uint >();
 			methodFullSignatureToIndex = new Dictionary< String, uint >();
-			foreach( var k in deserMethods )
+			for( int k = 0; k < mnum; k++ )
 			{
 				methods[id] = new CilboxMethod();
-				methods[id].Load( this, k.Key, k.Value );
-				methodNameToIndex[methods[id].methodName] = id;
+				methods[id].Load( this, sc.methods[k].fullSignature, sc.methods[k] );
+				methodNameToIndex[sc.methods[k].methodName] = id;
 				methodFullSignatureToIndex[methods[id].fullSignature] = id;
 				id++;
 			}
@@ -2176,7 +2138,7 @@ spiperf.End();
 			usage = new CilboxUsage( this );
 		}
 
-		abstract public bool CheckMethodAllowed( out MethodInfo mi, Type declaringType, String name, Serializee [] parametersIn, Serializee [] genericArgumentsIn, String fullSignature );
+		abstract public bool CheckMethodAllowed( out MethodInfo mi, Type declaringType, String name, SerializedTypeDescriptor [] parametersIn, SerializedTypeDescriptor [] genericArgumentsIn, String fullSignature );
 		abstract public bool CheckTypeAllowed( String sType );
 		abstract public bool CheckFieldAllowed( String sType, String sFieldName );
 		abstract public bool GetTypeOverride( String sType, out Type t );
@@ -2199,80 +2161,77 @@ spiperf.End();
 
 			if( initialized ) return;
 			initialized = true;
-			//Debug.Log( "Cilbox Initialize Metadata:" + assemblyData.Length );
 			timeoutLengthUs = desiredTimeoutLengthUs; // make sure min is applied once.
 
-			Dictionary< String, Serializee > assemblyRoot = new Serializee( Convert.FromBase64String( assemblyData ), Serializee.ElementType.Map ).AsMap();
-			Dictionary< String, Serializee > classData = assemblyRoot["classes"].AsMap();
-			Dictionary< String, Serializee > metaData = assemblyRoot["metadata"].AsMap();
+			if( assemblyData == null || assemblyData.Length == 0 )
+			{
+				Debug.LogError( "[Cilbox] No assembly binary data available. Did the compiler run?" );
+				return;
+			}
 
-			metadatas = new CilMetadataTokenInfo[metaData.Count+1]; // element 0 is invalid.
-			metadatas[0] = new CilMetadataTokenInfo( 0 );
-			metadatas[0].Name = "<INVALID>";
+			SerializedAssembly asm = SerializedAssembly.Deserialize( assemblyData );
 
+			// Register class names first (metadata resolution needs them)
 			int clsid = 0;
 			classes = new Dictionary< String, int >();
-			classesList = new CilboxClass[classData.Count];
-			foreach( var v in classData )
+			classesList = new CilboxClass[asm.classes.Length];
+			for( int i = 0; i < asm.classes.Length; i++ )
 			{
 				CilboxClass cls = new CilboxClass();
 				classesList[clsid] = cls;
-				classes[(String)v.Key] = clsid;
+				classes[asm.classes[i].className] = clsid;
 				clsid++;
 			}
 
+			// Enums
 			cilboxEnums = new Dictionary<string, CilboxEnum>();
-			Serializee enumsSer;
-			if (assemblyRoot.TryGetValue("enums", out enumsSer))
+			for( int i = 0; i < asm.enums.Length; i++ )
 			{
-				foreach (var kv in enumsSer.AsMap())
-				{
-					var enumProps = kv.Value.AsMap();
-					CilboxEnum ce = new CilboxEnum();
-					ce.enumName = kv.Key;
-					ce.underlyingType = StackElement.StackTypeFromType(usage.GetNativeTypeFromSerializee(enumProps["ut"]));
-					ce.valueToName = new Dictionary<long, string>();
-					foreach (var entry in enumProps["values"].AsArray())
-					{
-						var e = entry.AsMap();
-						ce.valueToName[Convert.ToInt64(e["v"].AsString())] = e["n"].AsString();
-					}
-					cilboxEnums[kv.Key] = ce;
-				}
+				SerializedEnum ee = asm.enums[i];
+				CilboxEnum ce = new CilboxEnum();
+				ce.enumName = ee.enumName;
+				ce.underlyingType = StackElement.StackTypeFromType(usage.GetNativeTypeFromDescriptor(ee.underlyingType));
+				ce.valueToName = new Dictionary<long, string>();
+				for( int v = 0; v < ee.values.Length; v++ )
+					ce.valueToName[ee.values[v].value] = ee.values[v].name;
+				cilboxEnums[ee.enumName] = ce;
 			}
 
-			clsid = 0;
-			foreach( var v in classData )
-				classesList[clsid++].LoadCilboxClass( this, v.Key, v.Value );
+			// Load classes
+			for( int i = 0; i < asm.classes.Length; i++ )
+				classesList[i].LoadCilboxClass( this, asm.classes[i].className, asm.classes[i] );
 
-			foreach( var v in metaData )
+			// Metadata — flat array, index 0 is sentinel
+			metadatas = new CilMetadataTokenInfo[asm.metadata.Length + 1];
+			metadatas[0] = new CilMetadataTokenInfo( 0 );
+			metadatas[0].Name = "<INVALID>";
+
+			for( int mid = 0; mid < asm.metadata.Length; mid++ )
 			{
-				int mid = Convert.ToInt32((String)v.Key);
-				Dictionary< String, Serializee > st = v.Value.AsMap();
-				MetaTokenType metatype = (MetaTokenType)Convert.ToInt32(st["mt"].AsString());
-				CilMetadataTokenInfo t = metadatas[mid] = new CilMetadataTokenInfo( metatype );
-
+				SerializedMetadataToken sm = asm.metadata[mid];
+				MetaTokenType metatype = (MetaTokenType)sm.metaTokenType;
+				CilMetadataTokenInfo t = metadatas[mid + 1] = new CilMetadataTokenInfo( metatype );
 				t.type = metatype;
 				t.Name = "<UNKNOWN>";
 
 				switch( metatype )
 				{
 				case MetaTokenType.mtString:
-					t.Name = st["s"].AsString();
+					t.Name = sm.stringValue;
 					break;
 				case MetaTokenType.mtArrayInitializer:
-					t.arrayInitializerData = st["data"].AsBlob();
+					t.arrayInitializerData = sm.arrayInitData;
 					break;
 				case MetaTokenType.mtField:
+				{
 					// The type has been "sealed" so-to-speak. In that we have an index for it.
+					t.Name = sm.fieldName;
+					t.declaringTypeName = usage.GetNativeTypeNameFromDescriptor( sm.fieldDeclaringType );
+					t.fieldIsStatic = sm.fieldIsStatic;
 
-					t.Name = st["name"].AsString();
-					t.declaringTypeName = usage.GetNativeTypeNameFromSerializee( st["dt"] );
-					t.fieldIsStatic = Convert.ToInt32(st["isStatic"].AsString()) != 0;
-
-					if( st.ContainsKey("index") )
+					if( sm.fieldHasIndex )
 					{
-						t.fieldIndex = Convert.ToInt32(st["index"].AsString());
+						t.fieldIndex = sm.fieldIndex;
 						if( classes.TryGetValue( t.declaringTypeName, out int fieldClassId ) )
 							t.interpretiveFieldClass = fieldClassId;
 					}
@@ -2281,15 +2240,14 @@ spiperf.End();
 						bool bAllowed = CheckFieldAllowed( t.declaringTypeName, t.Name );
 						if( !bAllowed )
 						{
-							throw new CilboxException( $"Illegal field reference outside of the cilbox. {t.declaringTypeName}.{t.Name} in {v.Key}." );
+							throw new CilboxException( $"Illegal field reference outside of the cilbox. {t.declaringTypeName}.{t.Name} in meta {mid+1}." );
 						}
 						t.isFieldWhiteListed = true;
 
-						Serializee typ = st["dt"];
-						Type ty = usage.GetNativeTypeFromSerializee( typ );
+						Type ty = usage.GetNativeTypeFromDescriptor( sm.fieldDeclaringType );
 						if( ty == null )
 						{
-							throw new CilboxException( $"Could not get allowed type for checking field, {t.declaringTypeName} in {v.Key}." );
+							throw new CilboxException( $"Could not get allowed type for checking field, {t.declaringTypeName} in meta {mid+1}." );
 						}
 
 						// We have a type for the declaring type, but, we need a field.
@@ -2297,12 +2255,12 @@ spiperf.End();
 
 						if( f == null )
 						{
-							throw new CilboxException( $"Could not find field for object type {t.declaringTypeName}.{t.Name} in {v.Key}." );
+							throw new CilboxException( $"Could not find field for object type {t.declaringTypeName}.{t.Name} in meta {mid+1}." );
 						}
 
 						if( !usage.CheckTypeSecurityRecursive( f.FieldType ) )
 						{
-							throw new CilboxException( $"Field for {t.declaringTypeName}.{t.Name} in {v.Key} of type {f.FieldType.ToString()} not allowed." );
+							throw new CilboxException( $"Field for {t.declaringTypeName}.{t.Name} in meta {mid+1} of type {f.FieldType.ToString()} not allowed." );
 						}
 
 						t.isFieldWhiteListed = true;
@@ -2322,19 +2280,15 @@ spiperf.End();
 						{
 							t.nativeTypeIsStackType = false;
 						}
-						//foreach(var i in st)
-						//{
-						//	Debug.Log( $"SS: {t.Name} {t.declaringTypeName} {i.Key}" );
-						//}
-						//throw new CilboxException( $"Currently cannot reference fields outside of the cilbox. {t.declaringTypeName} in {v.Key}.  Use properties." );
 					}
 
 					t.isValid = true;
 					break;
+				}
 				case MetaTokenType.mtType:
 				{
-					Serializee typ = st["dt"];
-					t.nativeType = usage.GetNativeTypeFromSerializee( typ );
+					SerializedTypeDescriptor td = sm.typeDescriptor;
+					t.nativeType = usage.GetNativeTypeFromDescriptor( td );
 					StackType seType = StackElement.StackTypeFromType( t.nativeType );
 					if( seType < StackType.Object )
 					{
@@ -2343,7 +2297,7 @@ spiperf.End();
 						t.Name = t.nativeType.ToString();
 
 						// Link to CilboxEnum if this was a cilboxable enum serialized by underlying type.
-						string origName = typ.AsMap()["n"].AsString();
+						string origName = td.typeName;
 						if (cilboxEnums != null && cilboxEnums.TryGetValue(origName, out CilboxEnum cilboxEnumDef))
 						{
 							t.cilboxEnum = cilboxEnumDef;
@@ -2353,17 +2307,15 @@ spiperf.End();
 					else if( t.nativeType != null )
 					{
 						t.isValid = true;
-						t.Name = "Type: " + typ.AsMap()["n"].AsString();
+						t.Name = "Type: " + td.typeName;
 					}
 					else
 					{
-						Dictionary< String, Serializee > typMap = typ.AsMap();
-
 						// Maybe it's a type inside our cilbox?
 						t.isValid = false;
 						foreach( CilboxClass c in classesList )
 						{
-							if( c.className == typMap["n"].AsString() )
+							if( c.className == td.typeName )
 							{
 								t.Name = c.className;
 								t.nativeTypeIsCilboxProxy = true;
@@ -2372,42 +2324,30 @@ spiperf.End();
 						}
 
 						if( !t.isValid )
-							Debug.LogError( $"Error: Could not find type: {typMap["n"].AsString()}" );
+							Debug.LogError( $"Error: Could not find type: {td.typeName}" );
 					}
 					break;
 				}
 				case MetaTokenType.mtMethod:
 				{
-					String name = st["name"].AsString();
-					String fullSignature = st["fullSignature"].AsString();
-					bool isStatic = Convert.ToInt32( st["isStatic"].AsString() ) != 0;
-					String useAssembly = st["assembly"].AsString();
-					Serializee [] genericArguments = null;
+					String name = sm.methodName;
+					String fullSignature = sm.methodFullSignature;
+					bool isStatic = sm.methodIsStatic;
+					String useAssembly = sm.methodAssembly;
+					SerializedTypeDescriptor[] genericArguments = sm.methodGenericArguments ?? new SerializedTypeDescriptor[0];
 					t.Name = "Method: " + name;
 
-					//Possibly get genericArguments
-					Serializee temp;
-					if( st.TryGetValue( "ga", out temp ) )
-						genericArguments = temp.AsArray();
-					else
-						genericArguments = new Serializee[0];
-
-					if( usage.OptionallyOverride( name, st["dt"], fullSignature, isStatic, genericArguments, ref t ) )
+					if( usage.OptionallyOverride( name, sm.methodDeclaringType, fullSignature, isStatic, genericArguments, ref t ) )
 					{
 						break;
 					}
 
-					Serializee stDt;
-					(name, stDt) = usage.HandleEarlyMethodRewrite( name, st["dt"], genericArguments );
+					SerializedTypeDescriptor stDt;
+					(name, stDt) = usage.HandleEarlyMethodRewrite( name, sm.methodDeclaringType, genericArguments );
 
-					string declaringTypeName = t.declaringTypeName = usage.GetNativeTypeNameFromSerializee( stDt );
+					string declaringTypeName = t.declaringTypeName = usage.GetNativeTypeNameFromDescriptor( stDt );
 
-
-					Serializee [] parametersSer = null;
-					if( st.TryGetValue( "parameters", out temp ) )
-						parametersSer = temp.AsArray();
-					else
-						parametersSer = new Serializee[0];
+					SerializedTypeDescriptor[] paramDescs = sm.methodParameters ?? new SerializedTypeDescriptor[0];
 
 					// First, see if this is to a class we are responsible for. Like does it come from _this_ class?
 					int classid;
@@ -2421,7 +2361,6 @@ spiperf.End();
 						uint imid = 0;
 						if( matchingClass.methodFullSignatureToIndex.TryGetValue( fullSignature, out imid ) )
 						{
-							//t.nativeToken = 0; // Sentinel for saying it's a cilbox'd class.
 							t.isNative = false;
 							t.interpretiveMethod = (int)imid;
 							t.interpretiveMethodClass = classid;
@@ -2435,11 +2374,11 @@ spiperf.End();
 					}
 					else
 					{
-						Type declaringType = usage.GetNativeTypeFromSerializee( stDt );
+						Type declaringType = usage.GetNativeTypeFromDescriptor( stDt );
 						if( declaringType == null )
 							throw new CilboxException( $"Error: Could not find referenced type {useAssembly}/{declaringTypeName}/" );
 
-						MethodBase m = usage.GetNativeMethodFromTypeAndName( declaringType, name, parametersSer,
+						MethodBase m = usage.GetNativeMethodFromTypeAndName( declaringType, name, paramDescs,
 							genericArguments, fullSignature );
 
 						if( m != null )
@@ -2646,7 +2585,7 @@ spiperf.End();
 			}
 
 
-			Dictionary< String, Serializee > assemblyMetadata = new Dictionary< String, Serializee >();
+			List< SerializedMetadataToken > assemblyMetadata = new List< SerializedMetadataToken >();
 			Dictionary< uint, String > originalMetaToFriendlyName = new Dictionary< uint, String >();
 			// This is used for remapping tokens in the bytecode to point to our own metadata.
 			// Since tokens are per-assembly, we need prevent collisions by keying per assembly as well.
@@ -2654,8 +2593,8 @@ spiperf.End();
 
 			uint mdcount = 1; // token 0 is invalid.
 			int bytecodeLength = 0;
-			Dictionary< String, Serializee > classes = new Dictionary<String, Serializee>();
-			Dictionary< String, Serializee > allClassMethods = new Dictionary< String, Serializee >();
+			Dictionary< String, SerializedClass > classes = new Dictionary<String, SerializedClass>();
+			Dictionary< String, SerializedMethod[] > allClassMethods = new Dictionary< String, SerializedMethod[] >();
 
 			perf.End(); perf = new ProfilerMarker( "Main Getting Types" ); perf.Begin();
 
@@ -2715,7 +2654,7 @@ spiperf.End();
 
 					ProfilerMarker perfType = new ProfilerMarker(type.ToString()); perfType.Begin();
 
-					Dictionary< String, Serializee > methods = new Dictionary< String, Serializee >();
+					List< SerializedMethod > methodsList = new List< SerializedMethod >();
 
 					int mtyp; // Which round of methods are we getting.
 					// Iterate twice. Once for methods, then for constructors.
@@ -2738,7 +2677,8 @@ spiperf.End();
 							ProfilerMarker perfMethod = new ProfilerMarker(m.ToString()); perfMethod.Begin();
 
 							String methodName = m.Name;
-							Dictionary< String, Serializee > MethodProps = new Dictionary< String, Serializee >();
+							SerializedMethod sm = new SerializedMethod();
+							sm.methodName = methodName;
 							MethodBody mb = m.GetMethodBody();
 							if( mb == null )
 							{
@@ -2809,12 +2749,13 @@ spiperf.End();
 													GCHandle h = GCHandle.Alloc(rf.GetValue(null), GCHandleType.Pinned);
 													Marshal.Copy(h.AddrOfPinnedObject(), bytes, 0, bytes.Length);
 													h.Free();
-													// Now, encode our array initializer to base64.
-													Dictionary< String, Serializee > thisMeta = new Dictionary< String, Serializee >();
-													thisMeta["mt"] = new Serializee(((int)MetaTokenType.mtArrayInitializer).ToString());
-													thisMeta["data"] = Serializee.CreateFromBlob( bytes );
+													// Now, encode our array initializer.
+													SerializedMetadataToken thisMeta = new SerializedMetadataToken();
+													thisMeta.metaTokenType = (byte)MetaTokenType.mtArrayInitializer;
+													thisMeta.arrayInitData = bytes;
 													originalMetaToFriendlyName[mdcount] = rf.Name;
-													assemblyMetadata[(mdcount++).ToString()] = new Serializee( thisMeta );
+													assemblyMetadata.Add( thisMeta );
+													mdcount++;
 												}
 												break;
 										/*
@@ -2824,10 +2765,11 @@ spiperf.End();
 													// TODO: Actually investigate this.  See if we really need it.
 													writebackToken = mdcount;
 													Type ty = proxyAssembly.ManifestModule.ResolveType( (int)operand );
-													Dictionary<String, Serializee> fieldProps = new Dictionary<String, Serializee>();
-													fieldProps["mt"] = new Serializee( ((int)MetaTokenType.mtType).ToString() );
-													fieldProps["dt"] = CilboxUtil.GetSerializeeFromNativeType( ty );
-													assemblyMetadata[(mdcount++).ToString()] = new Serializee( fieldProps );
+													SerializedMetadataToken typeMeta2 = new SerializedMetadataToken();
+													typeMeta2.metaTokenType = (byte)MetaTokenType.mtType;
+													typeMeta2.typeDescriptor = SerializedTypeDescriptorBuilder.FromNativeType( ty );
+													assemblyMetadata.Add( typeMeta2 );
+													mdcount++;
 													originalMetaToFriendlyName[writebackToken] = ty.FullName;
 												}
 												break;
@@ -2846,12 +2788,12 @@ spiperf.End();
 											if( !assemblyMetadataReverseOriginal.TryGetValue( (proxyAssembly, (int)operand), out writebackToken ) )
 											{
 												writebackToken = mdcount;
-												Dictionary< String, String > thisMeta = new Dictionary< String, String >();
-												String st = ((int)MetaTokenType.mtString).ToString();
-												thisMeta["mt"] = st;
-												thisMeta["s"] = proxyAssembly.ManifestModule.ResolveString( (int)operand );
-												originalMetaToFriendlyName[mdcount] = st;
-												assemblyMetadata[(mdcount++).ToString()] = new Serializee( thisMeta );
+												SerializedMetadataToken thisMeta = new SerializedMetadataToken();
+												thisMeta.metaTokenType = (byte)MetaTokenType.mtString;
+												thisMeta.stringValue = proxyAssembly.ManifestModule.ResolveString( (int)operand );
+												originalMetaToFriendlyName[mdcount] = thisMeta.stringValue;
+												assemblyMetadata.Add( thisMeta );
+												mdcount++;
 											}
 										}
 										else if( ot == CilboxUtil.OpCodes.OperandType.InlineMethod )
@@ -2861,7 +2803,13 @@ spiperf.End();
 												writebackToken = mdcount;
 												MethodBase tmb = proxyAssembly.ManifestModule.ResolveMethod( (int)operand );
 
-												Dictionary<String, Serializee> methodProps = new Dictionary<String, Serializee>();
+												SerializedMetadataToken metaTok = new SerializedMetadataToken();
+												metaTok.metaTokenType = (byte)MetaTokenType.mtMethod;
+												metaTok.methodDeclaringType = SerializedTypeDescriptorBuilder.FromNativeType( tmb.DeclaringType );
+												metaTok.methodName = tmb.Name;
+												metaTok.methodFullSignature = tmb.ToString();
+												metaTok.methodIsStatic = tmb.IsStatic;
+												metaTok.methodAssembly = tmb.DeclaringType.Assembly.GetName().Name;
 
 												// "Generic constructors are not supported in the .NET Framework version 2.0"
 												if( !tmb.IsConstructor )
@@ -2869,11 +2817,18 @@ spiperf.End();
 													Type[] templateArguments = tmb.GetGenericArguments();
 													if( templateArguments.Length > 0 )
 													{
-														Serializee [] argtypes = new Serializee[templateArguments.Length];
+														metaTok.methodGenericArguments = new SerializedTypeDescriptor[templateArguments.Length];
 														for( int a = 0; a < templateArguments.Length; a++ )
-															argtypes[a] = CilboxUtil.GetSerializeeFromNativeType( templateArguments[a] );
-														methodProps["ga"] = new Serializee( argtypes );
+															metaTok.methodGenericArguments[a] = SerializedTypeDescriptorBuilder.FromNativeType( templateArguments[a] );
 													}
+													else
+													{
+														metaTok.methodGenericArguments = new SerializedTypeDescriptor[0];
+													}
+												}
+												else
+												{
+													metaTok.methodGenericArguments = new SerializedTypeDescriptor[0];
 												}
 
 												// If we are using another type here, make sure it gets in our list.
@@ -2884,26 +2839,14 @@ spiperf.End();
 													TypesInUseInSceneList.Add( tmb.DeclaringType );
 												}
 
-												methodProps["dt"] = CilboxUtil.GetSerializeeFromNativeType( tmb.DeclaringType );
-												methodProps["name"] = new Serializee( tmb.Name );
-
 												System.Reflection.ParameterInfo[] parameterInfos = tmb.GetParameters();
-												if( parameterInfos.Length > 0 )
-												{
-													Serializee [] parametersSer = new Serializee[parameterInfos.Length];
-													for( var j = 0; j < parameterInfos.Length; j++ )
-													{
-														Type ty = parameterInfos[j].ParameterType;
-														parametersSer[j] = CilboxUtil.GetSerializeeFromNativeType( ty );
-													}
-													methodProps["parameters"] = new Serializee( parametersSer );
-												}
-												methodProps["fullSignature"] = new Serializee( tmb.ToString() );
-												methodProps["isStatic"] = new Serializee( tmb.IsStatic?"1":"0" );
-												methodProps["assembly"] = new Serializee( tmb.DeclaringType.Assembly.GetName().Name );
-												methodProps["mt"] = new Serializee(((int)MetaTokenType.mtMethod).ToString());
+												metaTok.methodParameters = new SerializedTypeDescriptor[parameterInfos.Length];
+												for( int j = 0; j < parameterInfos.Length; j++ )
+													metaTok.methodParameters[j] = SerializedTypeDescriptorBuilder.FromNativeType( parameterInfos[j].ParameterType );
+
 												originalMetaToFriendlyName[writebackToken] = tmb.DeclaringType.ToString() + "." + tmb.ToString();
-												assemblyMetadata[(mdcount++).ToString()] = new Serializee( methodProps );
+												assemblyMetadata.Add( metaTok );
+												mdcount++;
 											}
 										}
 										else if( ot == CilboxUtil.OpCodes.OperandType.InlineField )
@@ -2923,14 +2866,14 @@ spiperf.End();
 													changeOperand = true; // We need to rewrite the operand to point to our new metadata for the field, which will have a reference to the declaring type.
 												}
 
-												Dictionary<String, Serializee> fieldProps = new Dictionary<String, Serializee>();
-												fieldProps["mt"] = new Serializee( ((int)MetaTokenType.mtField).ToString() );
-												fieldProps["dt"] = CilboxUtil.GetSerializeeFromNativeType( rf.DeclaringType );
-												fieldProps["name"] = new Serializee( rf.Name );
-												//fieldProps["fullName"] = rf.FieldType.FullName;
-												fieldProps["isStatic"] = new Serializee( (rf.IsStatic?1:0).ToString() );
+												SerializedMetadataToken fieldMeta = new SerializedMetadataToken();
+												fieldMeta.metaTokenType = (byte)MetaTokenType.mtField;
+												fieldMeta.fieldDeclaringType = SerializedTypeDescriptorBuilder.FromNativeType( rf.DeclaringType );
+												fieldMeta.fieldName = rf.Name;
+												fieldMeta.fieldIsStatic = rf.IsStatic;
 												originalMetaToFriendlyName[writebackToken] = rf.Name;
-												assemblyMetadata[(mdcount++).ToString()] = new Serializee(fieldProps);
+												assemblyMetadata.Add( fieldMeta );
+												mdcount++;
 											}
 										}
 										else if( ot == CilboxUtil.OpCodes.OperandType.InlineType )
@@ -2939,10 +2882,11 @@ spiperf.End();
 											{
 												writebackToken = mdcount;
 												Type ty = proxyAssembly.ManifestModule.ResolveType( (int)operand );
-												Dictionary<String, Serializee> fieldProps = new Dictionary<String, Serializee>();
-												fieldProps["mt"] = new Serializee( ((int)MetaTokenType.mtType).ToString() );
-												fieldProps["dt"] = CilboxUtil.GetSerializeeFromNativeType( ty );
-												assemblyMetadata[(mdcount++).ToString()] = new Serializee( fieldProps );
+												SerializedMetadataToken typeMeta = new SerializedMetadataToken();
+												typeMeta.metaTokenType = (byte)MetaTokenType.mtType;
+												typeMeta.typeDescriptor = SerializedTypeDescriptorBuilder.FromNativeType( ty );
+												assemblyMetadata.Add( typeMeta );
+												mdcount++;
 												originalMetaToFriendlyName[writebackToken] = ty.FullName;
 											}
 										}
@@ -2966,67 +2910,59 @@ spiperf.End();
 							}
 
 							bytecodeLength += byteCode.Length;
-							MethodProps["body"] = Serializee.CreateFromBlob(byteCode);
+							sm.body = byteCode;
 
 							IList<ExceptionHandlingClause> exceptions = mb.ExceptionHandlingClauses;
-							if( exceptions.Count > 0 )
+							sm.exceptionHandlers = new SerializedExceptionHandler[exceptions.Count];
+							for( int k = 0; k < exceptions.Count; k++ )
 							{
-								Serializee [] excArray = new Serializee[exceptions.Count];
-								for( int k = 0; k < exceptions.Count; k++ )
+								ExceptionHandlingClause c = exceptions[k];
+								SerializedExceptionHandler seh = new SerializedExceptionHandler();
+								seh.flags = (int)c.Flags;
+								seh.tryOffset = c.TryOffset;
+								seh.tryLength = c.TryLength;
+								seh.handlerOffset = c.HandlerOffset;
+								seh.handlerLength = c.HandlerLength;
+								if( c.Flags == ExceptionHandlingClauseOptions.Clause && c.CatchType != null )
 								{
-									ExceptionHandlingClause c = exceptions[k];
-									Dictionary< String, Serializee > exc = new Dictionary< String, Serializee >();
-									exc["flags"] = new Serializee( ((int)c.Flags).ToString() );
-									exc["tryOff"] = new Serializee( c.TryOffset.ToString() );
-									exc["tryLen"] = new Serializee( c.TryLength.ToString() );
-									exc["hOff"] = new Serializee( c.HandlerOffset.ToString() );
-									exc["hLen"] = new Serializee( c.HandlerLength.ToString() );
-
-									if( c.Flags == ExceptionHandlingClauseOptions.Clause && c.CatchType != null )
-									{
-										exc["cType"] = CilboxUtil.GetSerializeeFromNativeType( c.CatchType );
-									}
-									excArray[k] = new Serializee( exc );
+									seh.hasCatchType = true;
+									seh.catchType = SerializedTypeDescriptorBuilder.FromNativeType( c.CatchType );
 								}
-								MethodProps["eh"] = new Serializee( excArray );
+								sm.exceptionHandlers[k] = seh;
 							}
 
-							Serializee [] localVars = new Serializee[mb.LocalVariables.Count];
+							sm.locals = new SerializedField[mb.LocalVariables.Count];
 							for( int i = 0; i < mb.LocalVariables.Count; i++ )
 							{
 								LocalVariableInfo lvi = mb.LocalVariables[i];
-								Dictionary< String, Serializee > local = new Dictionary< String, Serializee >();
-								local["name"] = new Serializee( lvi.ToString() );
-								local["dt"] = CilboxUtil.GetSerializeeFromNativeType( lvi.LocalType );
-								localVars[i] = new Serializee( local );
+								SerializedField sl = new SerializedField();
+								sl.name = lvi.ToString();
+								sl.type = SerializedTypeDescriptorBuilder.FromNativeType( lvi.LocalType );
+								sm.locals[i] = sl;
 							}
-							MethodProps["locals"] = new Serializee( localVars );
 
 							ParameterInfo [] parameters = m.GetParameters();
-
-							Serializee [] parameterList = new Serializee[parameters.Length];
+							sm.parameters = new SerializedField[parameters.Length];
 							for( int i = 0; i < parameters.Length; i++ )
 							{
-								Dictionary< String, Serializee > tpi = new Dictionary< String, Serializee >();
-								tpi["name"] = new Serializee( parameters[i].Name );
-								tpi["dt"] = CilboxUtil.GetSerializeeFromNativeType( parameters[i].ParameterType );
-								parameterList[i] = new Serializee( tpi );
+								SerializedField sp = new SerializedField();
+								sp.name = parameters[i].Name;
+								sp.type = SerializedTypeDescriptorBuilder.FromNativeType( parameters[i].ParameterType );
+								sm.parameters[i] = sp;
 							}
-							MethodProps["parameters"] = new Serializee( parameterList );
-							MethodProps["maxStack"] = new Serializee( mb.MaxStackSize.ToString() );
+							sm.maxStack = mb.MaxStackSize;
 							bool isCtor = m.IsConstructor;
-							MethodProps["isVoid"] = new Serializee( (m is MethodInfo)?(((MethodInfo)m).ReturnType == typeof(void) ? "1" : "0" ): (isCtor ? "1" : "0") );
-							MethodProps["isCtor"] = new Serializee( isCtor ? "1" : "0" );
-							MethodProps["isStatic"] = new Serializee( m.IsStatic ? "1" : "0" );
-							MethodProps["name"] = new Serializee( methodName );
-							MethodProps["fullSignature"] = new Serializee( m.ToString() );
+							sm.isVoid = (m is MethodInfo) ? (((MethodInfo)m).ReturnType == typeof(void)) : isCtor;
+							sm.isCtor = isCtor;
+							sm.isStatic = m.IsStatic;
+							sm.fullSignature = m.ToString();
 
-							methods[m.ToString()] = new Serializee( MethodProps );
+							methodsList.Add( sm );
 							perfMethod.End();
 						}
 					}
 
-					allClassMethods[type.FullName] = new Serializee( methods );
+					allClassMethods[type.FullName] = methodsList.ToArray();
 					perfType.End();
 				}
 			}
@@ -3049,14 +2985,15 @@ spiperf.End();
 
 					ProfilerMarker perfType = new ProfilerMarker(type.ToString()); perfType.Begin();
 
-					Dictionary< String, Serializee > classProps = new Dictionary< String, Serializee >();
+					SerializedClass sc = new SerializedClass();
+					sc.className = type.FullName;
 
 					// This portion extracts the index information from the current type, and
 					// Writes it back in where it was needed above in the Method call.
 					//
 					for( int lst = 0; lst < 2; lst++ )
 					{
-						List< Serializee > fields = new List< Serializee >();
+						List< SerializedField > fields = new List< SerializedField >();
 						int sfid = 0;
 						FieldInfo[] fi;
 						if( lst == 0 )
@@ -3065,81 +3002,87 @@ spiperf.End();
 							fi = type.GetFields( BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance );
 						foreach( var f in fi )
 						{
-							Dictionary< String, Serializee > dictField = new Dictionary< String, Serializee >();
-							dictField["name"] = new Serializee( f.Name );
-							dictField["type"] = CilboxUtil.GetSerializeeFromNativeType( f.FieldType );
-							fields.Add( new Serializee( dictField ) );
+							SerializedField sf = new SerializedField();
+							sf.name = f.Name;
+							sf.type = SerializedTypeDescriptorBuilder.FromNativeType( f.FieldType );
+							fields.Add( sf );
 
 							// Fill in our metadata with a class-specific field ID, if this field ID was used in code anywhere.
 							uint mdid;
 							if( assemblyMetadataReverseOriginal.TryGetValue((type.Assembly, f.MetadataToken), out mdid) )
 							{
-								Serializee sOpen = assemblyMetadata[mdid.ToString()];
-								Dictionary< String, Serializee > m = sOpen.AsMap();
-								m["index"] = new Serializee( sfid.ToString() );
-								assemblyMetadata[mdid.ToString()] = new Serializee( m );
+								// mdid is 1-based, assemblyMetadata list is 0-based
+								SerializedMetadataToken metaTok = assemblyMetadata[(int)(mdid - 1)];
+								metaTok.fieldHasIndex = true;
+								metaTok.fieldIndex = sfid;
 							}
 							sfid++;
 						}
-						classProps[(lst == 0 )?"staticFields":"instanceFields"] = new Serializee( fields.ToArray() );
+						if( lst == 0 )
+							sc.staticFields = fields.ToArray();
+						else
+							sc.instanceFields = fields.ToArray();
 					}
 
-					classProps["methods"] = allClassMethods[type.FullName];
+					sc.methods = allClassMethods[type.FullName];
 
 					// Only [Cilboxable] ancestors are recorded: a native/prohibited base is never emitted, so GetComponent<T>
 					// base-matching can never name a non-sandboxed class (and a match only ever yields an interpreted proxy).
-					List< Serializee > baseClassChain = new List< Serializee >();
+					List< string > baseClassChain = new List< string >();
 					for( Type bt = type.BaseType; bt != null && bt != typeof( UnityEngine.MonoBehaviour ) && bt != typeof( object ); bt = bt.BaseType )
 						if( CilboxUtil.HasCilboxableAttribute( bt ) )
-							baseClassChain.Add( new Serializee( bt.FullName ) );
-					classProps["baseClasses"] = new Serializee( baseClassChain.ToArray() );
-					classes[type.FullName] = new Serializee( classProps );
+							baseClassChain.Add( bt.FullName );
+					sc.baseClassNames = baseClassChain.ToArray();
+
+					classes[type.FullName] = sc;
 					perfType.End();
 				}
 			}
 
 			perf.End(); perf = new ProfilerMarker( "Assembling" ); perf.Begin();
 
-			Dictionary< String, Serializee > enumsDict = new Dictionary< String, Serializee >();
+			List< SerializedEnum > enumsList = new List< SerializedEnum >();
 			foreach( System.Reflection.Assembly proxyAssembly in assys )
 			{
 				foreach (Type type in proxyAssembly.GetTypes())
 				{
 					if (!type.IsEnum || !CilboxUtil.HasCilboxableAttribute(type))
 						continue;
-					Dictionary< String, Serializee > enumProps = new Dictionary< String, Serializee >();
-					enumProps["ut"] = CilboxUtil.GetSerializeeFromNativeType(type.GetEnumUnderlyingType());
+					SerializedEnum se = new SerializedEnum();
+					se.enumName = type.FullName;
+					se.underlyingType = SerializedTypeDescriptorBuilder.FromNativeType(type.GetEnumUnderlyingType());
 					string[] names = Enum.GetNames(type);
 					Array values = Enum.GetValues(type);
-					Serializee[] entries = new Serializee[names.Length];
+					se.values = new SerializedEnumValue[names.Length];
 					for (int i = 0; i < names.Length; i++)
 					{
-						Dictionary< String, Serializee > entry = new Dictionary< String, Serializee >();
-						entry["n"] = new Serializee(names[i]);
-						entry["v"] = new Serializee(Convert.ToInt64(values.GetValue(i)).ToString());
-						entries[i] = new Serializee(entry);
+						SerializedEnumValue sv = new SerializedEnumValue();
+						sv.name = names[i];
+						sv.value = Convert.ToInt64(values.GetValue(i));
+						se.values[i] = sv;
 					}
-					enumProps["values"] = new Serializee(entries);
-					enumsDict[type.FullName] = new Serializee(enumProps);
+					enumsList.Add( se );
 				}
 			}
 
-			Dictionary< String, Serializee > assemblyRoot = new Dictionary< String, Serializee >();
-			assemblyRoot["classes"] = new Serializee( classes );
-			assemblyRoot["metadata"] = new Serializee( assemblyMetadata );
-			assemblyRoot["enums"] = new Serializee( enumsDict );
-			Serializee assemblySerializee = new Serializee( assemblyRoot );
-
 			perf.End(); perf = new ProfilerMarker( "Serializing" ); perf.Begin();
 
-			String sAllAssemblyData = Convert.ToBase64String(assemblySerializee.DumpAsMemory().ToArray() );
+			// Build binary assembly directly
+			SerializedAssembly serializedAssembly = new SerializedAssembly();
+			serializedAssembly.classes = new SerializedClass[classes.Count];
+			int classIdx = 0;
+			foreach( KeyValuePair<string, SerializedClass> kv in classes )
+				serializedAssembly.classes[classIdx++] = kv.Value;
+			serializedAssembly.metadata = assemblyMetadata.ToArray();
+			serializedAssembly.enums = enumsList.ToArray();
+			String newAssemblyData = serializedAssembly.Serialize();
 
 			perf.End(); perf = new ProfilerMarker( "Checking If Assembly Changed" ); perf.Begin();
 
-			Cilbox [] se = Resources.FindObjectsOfTypeAll(typeof(Cilbox)) as Cilbox [];
+			Cilbox [] cilboxInstances = Resources.FindObjectsOfTypeAll(typeof(Cilbox)) as Cilbox [];
 			Cilbox tac = null;
 
-			foreach ( var tacCandidate in se ) {
+			foreach ( var tacCandidate in cilboxInstances ) {
 				if ( tacCandidate.gameObject.scene.IsValid() && !EditorUtility.IsPersistent(tacCandidate) ) {
 					tac = tacCandidate;
 					break;
@@ -3148,7 +3091,7 @@ spiperf.End();
 
 			if( tac != null )
 			{
-				if( tac.assemblyData != sAllAssemblyData ) EditorUtility.SetDirty( tac );
+				if( tac.assemblyData != newAssemblyData ) EditorUtility.SetDirty( tac );
 			}
 			else
 			{
@@ -3165,7 +3108,7 @@ spiperf.End();
 				GameObject gameObjectAsm = new GameObject("CilboxAsm " + new System.Random().Next(0,10000000));
 				Cilbox b = gameObjectAsm.AddComponent( tac.GetType() ) as Cilbox;
 				new Task( () => {
-					CilboxUtil.AssemblyLoggerTask( Application.dataPath + "/CilboxLog.txt", sAllAssemblyData, b );
+					CilboxUtil.AssemblyLoggerTask( Application.dataPath + "/CilboxLog.txt", newAssemblyData, b );
 					UnityEngine.Events.UnityAction deleter = null;
 					deleter = () => { GameObject.Destroy( gameObjectAsm ); Application.onBeforeRender -= deleter; };
 					Application.onBeforeRender += deleter;
@@ -3243,7 +3186,7 @@ spiperf.End();
 			}
 			else
 			{
-				tac.assemblyData = sAllAssemblyData;
+				tac.assemblyData = newAssemblyData;
 				tac.ForceReinit();
 			}
 

--- a/Packages/com.cnlohr.cilbox/CilboxProxy.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxProxy.cs
@@ -54,7 +54,7 @@ namespace Cilbox
 			fieldsObjects = new List< UnityEngine.Object >();
 			FieldInfo[] fi = mToSteal.GetType().GetFields( BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance );
 
-			List< Serializee > lstObjects = new List< Serializee >();
+			List< SerializedProxyField > lstFields = new List< SerializedProxyField >();
 
 			foreach( var f in fi )
 			{
@@ -80,49 +80,32 @@ namespace Cilbox
 					continue;
 				}
 
-				Serializee e = SerializeThing( fv, f.Name, matchingInstanceNameID, ref refToProxyMap );
-
 				// Serialize no matter what.
-				lstObjects.Add( e );
+				lstFields.Add( SerializeProxyField( fv, f.Name, matchingInstanceNameID, ref refToProxyMap ) );
 			}
 
-			serializedObjectData =
-				Convert.ToBase64String(new Serializee(lstObjects.ToArray()).DumpAsMemory().ToArray());
+			SerializedProxy proxy = new SerializedProxy();
+			proxy.fields = lstFields.ToArray();
+			serializedObjectData = proxy.Serialize();
 
 			buildTimeGuid = Guid.NewGuid().ToString();
-
-			//Debug.Log( $"SERIALIZE --> {serializedObjectData}" );
 		}
 
 
-		private Serializee SerializeThing( object fv, String fName, int matchingInstanceNameID, ref Dictionary< MonoBehaviour, CilboxProxy > refToProxyMap )
+		private SerializedProxyField SerializeProxyField( object fv, String fName, int matchingInstanceNameID, ref Dictionary< MonoBehaviour, CilboxProxy > refToProxyMap )
 		{
-			Dictionary<String, Serializee> instanceFields = new Dictionary<String, Serializee>();
-
-			// "n" is the "name" of the variable, only useful for object-root objects.
-			// "miid" = Field ID.
-			// "t" = Type
-			// "d" = Data (If applicable) (For strings and StackElements)
+			SerializedProxyField spf = new SerializedProxyField();
+			spf.fieldName = fName;
+			spf.matchingInstanceId = matchingInstanceNameID;
 
 			// Skip null objects.
 			if( fv == null )
 			{
-				instanceFields["empty"] = new Serializee( "true" );
-				return new Serializee(instanceFields);
+				spf.fieldType = (byte)ProxyFieldType.Empty;
+				return spf;
 			}
 
 			bool hasCilboxable = CilboxUtil.HasCilboxableAttribute( fv.GetType() );
-
-
-			if( fName != null )
-			{
-				instanceFields["n"] = new Serializee(fName);
-			}
-
-			if( matchingInstanceNameID >= 0 )
-			{
-				instanceFields["miid"] = new Serializee(matchingInstanceNameID.ToString());
-			}
 
 			StackType st;
 
@@ -132,65 +115,60 @@ namespace Cilbox
 				object underlying = Convert.ChangeType( fv, fv.GetType().GetEnumUnderlyingType() );
 				if( StackElement.TypeToStackType.TryGetValue( underlying.GetType().ToString(), out st ) && st < StackType.Object )
 				{
-					instanceFields["d"] = new Serializee(underlying.ToString());
-					instanceFields["t"] = new Serializee("e" + st);
+					spf.fieldType = (byte)ProxyFieldType.Primitive;
+					spf.primitiveValue.Unbox( underlying, st );
 				}
 			}
 			// Not a proxiable script.
 			else if (hasCilboxable)
 			{
-				// This is a cilboxable thing.
-				instanceFields["fo"] = new Serializee(fieldsObjects.Count.ToString());
+				spf.fieldType = (byte)ProxyFieldType.CilboxRef;
+				spf.fieldObjectIndex = fieldsObjects.Count;
+				spf.objectRefName = fv.ToString();
+				spf.objectRefIsNull = spf.objectRefName == "null";
 				fieldsObjects.Add( refToProxyMap[(MonoBehaviour)fv] );
-				instanceFields["t"] = new Serializee("cba");
-				instanceFields["or"] = new Serializee(fv.ToString());
 			}
 			else if( fv is UnityEngine.Object )
 			{
-				instanceFields["fo"] = new Serializee(fieldsObjects.Count.ToString());
+				spf.fieldType = (byte)ProxyFieldType.ObjectRef;
+				spf.fieldObjectIndex = fieldsObjects.Count;
+				spf.objectRefName = fv.ToString();
+				spf.objectRefIsNull = spf.objectRefName == "null";
 				fieldsObjects.Add( (UnityEngine.Object)fv );
-				instanceFields["t"] = new Serializee("obj");
-				instanceFields["or"] = new Serializee(fv.ToString());
 			}
 			else if( fv is string )
 			{
-				instanceFields["d"] = new Serializee(fv.ToString());
-				instanceFields["t"] = new Serializee("s");
+				spf.fieldType = (byte)ProxyFieldType.String;
+				spf.data = fv.ToString();
 			}
 			else if( StackElement.TypeToStackType.TryGetValue( fv.GetType().ToString(), out st ) && st < StackType.Object )
 			{
-				instanceFields["d"] = new Serializee(fv.ToString());
-				instanceFields["t"] = new Serializee("e" + st);
+				spf.fieldType = (byte)ProxyFieldType.Primitive;
+				spf.primitiveValue.Unbox( fv, st );
 			}
 			else if( fv.GetType().IsArray )
 			{
-				instanceFields["t"] = new Serializee( "a" );
+				spf.fieldType = (byte)ProxyFieldType.Array;
 				Type type = fv.GetType().GetElementType();
-				instanceFields["at"] = CilboxUtil.GetSerializeeFromNativeType( type );
+				spf.elementType = SerializedTypeDescriptorBuilder.FromNativeType( type );
 				Array arr = (Array)fv;
 				int len = arr.Length;
-				instanceFields["al"] = new Serializee( len.ToString() );
-
-				Serializee [] sel = new Serializee[len];
-				int i;
-				for( i = 0; i < len; i++ )
+				spf.arrayElements = new SerializedProxyField[len];
+				for( int i = 0; i < len; i++ )
 				{
 					object o = arr.GetValue(i);
-					sel[i] = SerializeThing( o, null, -1, ref refToProxyMap );
+					spf.arrayElements[i] = SerializeProxyField( o, null, -1, ref refToProxyMap );
 				}
-				instanceFields["ad"] = new Serializee( sel );
 			}
 			else
 			{
-				string json = JsonUtility.ToJson(fv);
-				instanceFields["t"] = new Serializee( "j" );
-				instanceFields["d"] = new Serializee(json);
+				spf.fieldType = (byte)ProxyFieldType.Json;
+				spf.data = JsonUtility.ToJson(fv);
 				Type type = fv.GetType();
-				instanceFields["at"] = CilboxUtil.GetSerializeeFromNativeType( type );
+				spf.elementType = SerializedTypeDescriptorBuilder.FromNativeType( type );
 			}
 
-
-			return new Serializee(instanceFields);
+			return spf;
 		}
 
 #endif
@@ -272,32 +250,25 @@ namespace Cilbox
 				}
 
 				// Populate fields[]
-				int fieldCount = cls.instanceFieldNames.Length;
-				fields = new StackElement[fieldCount];
+				fields = new StackElement[cls.instanceFieldNames.Length];
 
-				Serializee [] d = new Serializee( Convert.FromBase64String( serializedObjectData ), Serializee.ElementType.Map ).AsArray();
+				SerializedProxy proxyData = SerializedProxy.Deserialize( serializedObjectData );
 
-				Serializee [] matchingSerializeeInstanceField = new Serializee[fieldCount];
-				Dictionary< String, Serializee > [] matchingDicts = new Dictionary< String, Serializee >[fieldCount];
-				foreach( Serializee s in d )
+				SerializedProxyField[] matchingProxyField = new SerializedProxyField[cls.instanceFieldNames.Length];
+				foreach( SerializedProxyField spf in proxyData.fields )
 				{
 					// Go over the root objects, to see which ones slot in and how.
-					// Cache the parsed dict so the load pass below doesn't reparse.
-					Dictionary< String, Serializee > dict = s.AsMap();
-					if( dict.ContainsKey( "t" ) && dict.TryGetValue( "miid", out Serializee miid ) )
+					if( (ProxyFieldType)spf.fieldType != ProxyFieldType.Empty &&
+						spf.matchingInstanceId >= 0 &&
+						spf.matchingInstanceId < matchingProxyField.Length )
 					{
-						if( UInt32.TryParse( miid.AsString(), out UInt32 nMIID ) &&
-							nMIID < fieldCount )
-						{
-							matchingSerializeeInstanceField[nMIID] = s;
-							matchingDicts[nMIID] = dict;
-						}
+						matchingProxyField[spf.matchingInstanceId] = spf;
 					}
 				}
 
 				// Preinitialize every field to its CLR default value so that non-serialized fields
 				// (especially UnityEngine.Object references) are not left as implicit StackType.Boolean.
-				for( int i = 0; i < fieldCount; i++ )
+				for( int i = 0; i < cls.instanceFieldNames.Length; i++ )
 				{
 					Type fieldType = cls.instanceFieldTypes[i];
 					// Maybe need to GetComponentTypeOverride here as well?  Maybe not, since that should only be for actual UnityEngine.Objects, which should be null at this point if they are contraband.
@@ -329,6 +300,13 @@ namespace Cilbox
 							Debug.LogWarning( $"[CilboxProxy:{gameObject.name}] Failed to create default value for {cls.instanceFieldNames[i]} ({fieldType}): {e.Message}" );
 						}
 					}
+					else if( fieldType == typeof(string) )
+					{
+						// Empty/unset string fields default to string.Empty (matches Unity), not null.
+						fields[i].LoadObject( string.Empty );
+						if (verboseLogging)
+							ProxyDebugLog( $"Default field init {cls.instanceFieldNames[i]} <- string.Empty" );
+					}
 					else
 					{
 						fields[i].LoadObject( null );
@@ -341,14 +319,26 @@ namespace Cilbox
 				box.InterpretIID( cls, this, ImportFunctionID.dotCtor, null );
 
 				// load serialized fields.
-				for( int i = 0; i < fieldCount; i++ )
+				for( int i = 0; i < cls.instanceFieldNames.Length; i++ )
 				{
-					Serializee s = matchingSerializeeInstanceField[i];
+					SerializedProxyField spf = matchingProxyField[i];
 
-					if( s == null ) { /* Debug.Log( $"Skipping {i} {cls.instanceFieldNames[i]}" ); */ continue; }
+					if( spf == null ) { /* Debug.Log( $"Skipping {i} {cls.instanceFieldNames[i]}" ); */ continue; }
+
+					// Primitive: expand the 16-byte PrimitivePayload into the 24-byte StackElement.
+					// `l` overlaps b/f/d/e in both structs, so a single 8-byte copy at offset 8
+					// captures the entire union. No boxing, no allocation.
+					if( (ProxyFieldType)spf.fieldType == ProxyFieldType.Primitive )
+					{
+						ref StackElement dst = ref fields[i];
+						dst.type = spf.primitiveValue.type;
+						dst.l    = spf.primitiveValue.l;   // entire 8-byte union
+						dst.o    = null;                   // clear any prior ref
+						continue;
+					}
 
 					object o;
-					bool bIsObject = LoadObjectFromSerializee( s, out o, cls.instanceFieldNames[i], cls.instanceFieldTypes[i], true, matchingDicts[i] );
+					bool bIsObject = LoadObjectFromProxyField( spf, out o, cls.instanceFieldNames[i], cls.instanceFieldTypes[i] );
 					if( bIsObject )
 						fields[i].LoadObject( o );
 					else
@@ -370,143 +360,156 @@ namespace Cilbox
 
 
 		// Returns: true if is object, otherwise is primitive.
-		// `dict` may be supplied by callers that already parsed the Serializee to avoid a redundant AsMap allocation.
-		private bool LoadObjectFromSerializee( Serializee s, out object oOut, String rootFieldName, Type inType, bool root, Dictionary< String, Serializee > dict = null )
+		private bool LoadObjectFromProxyField( SerializedProxyField spf, out object oOut, String rootFieldName, Type inType )
 		{
+			ProxyFieldType ft = (ProxyFieldType)spf.fieldType;
 			List<UnityEngine.Object> objectSlots = runtimeFieldsObjects ?? fieldsObjects;
-			if( dict == null ) dict = s.AsMap();
 
-			Serializee setype;
-			if( dict.TryGetValue( "t", out setype ) )
+			switch (ft)
 			{
-				String sT = setype.AsString();
-				if( sT == "cba" || sT == "obj" )
+			case ProxyFieldType.CilboxRef:
+			case ProxyFieldType.ObjectRef:
+			{
+				int iFO = spf.fieldObjectIndex;
+				if( iFO >= 0 && iFO < objectSlots.Count )
 				{
-					Serializee seFO;
-					int iFO;
-					if( dict.TryGetValue( "fo", out seFO ) &&
-						Int32.TryParse( seFO.AsString(), out iFO ) &&
-						objectSlots != null &&
-						iFO >= 0 &&
-						iFO < objectSlots.Count )
+					if( spf.objectRefIsNull )
 					{
-						if (dict.TryGetValue("or", out var seOr))
-						{
-							if (seOr.AsString() == "null")
-							{
-								// This field was null when serialized, so just return null
-								oOut = null;
-								return true;
-							}
-						}
+						// This field was null when serialized, so just return null
+						oOut = null;
+						return true;
+					}
 
-						UnityEngine.Object o = objectSlots[iFO];
+					UnityEngine.Object o = objectSlots[iFO];
 
-						//Debug.Log( $"LOADING FIELD: {i} with {o}" );
-						if( o )
-						{
-							if( o is CilboxProxy )
-								((CilboxProxy)o).RuntimeProxyLoad();
+					if( o )
+					{
+						if( o is CilboxProxy )
+							((CilboxProxy)o).RuntimeProxyLoad();
 
-							oOut = o;
+						oOut = o;
 
-							// Remove reference out of the fieldsObjects array.
-							objectSlots[iFO] = null;
+						// Remove reference out of the fieldsObjects array.
+						objectSlots[iFO] = null;
 
-							return true;
-						}
-						Debug.LogWarning( $"[CilboxProxy:{gameObject.name}] Object reference slot {iFO} for field {rootFieldName} is null/missing at load time." );
+						return true;
+					}
+					Debug.LogWarning( $"[CilboxProxy:{gameObject.name}] Object reference slot {iFO} for field {rootFieldName} is null/missing at load time." );
+				}
+				else
+				{
+					Debug.LogWarning( $"Failure to load object in field id:{rootFieldName} of {className} (slot out of range, fieldsObjects count={objectSlots.Count})");
+				}
+				break;
+			}
+
+			case ProxyFieldType.Array:
+			{
+				Type t = box.usage.GetNativeTypeFromDescriptor( spf.elementType );
+				bool isCilboxElementType = false;
+
+				if (t == null)
+				{
+					String elementTypeName = spf.elementType.typeName;
+					if (box.classes.ContainsKey(elementTypeName))
+					{
+						// Check the array to see if it is Cilboxed
+						t = typeof(CilboxProxy);
+						isCilboxElementType = true;
 					}
 					else
 					{
-						int objectSlotCount = objectSlots != null ? objectSlots.Count : 0;
-						Debug.LogWarning( $"Failure to load object in field id:{rootFieldName} of {className} (slot parse failed or out of range, fieldsObjects count={objectSlotCount})");
-					}
-				}
-				else if( sT[0] == 'a' )
-				{
-					Serializee seT, seAT, seAL, seAD;
-					int aLen;
-					if( dict.TryGetValue( "t", out seT ) &&
-						dict.TryGetValue( "at", out seAT ) &&
-						dict.TryGetValue( "al", out seAL ) &&
-						dict.TryGetValue( "ad", out seAD ) &&
-						Int32.TryParse( seAL.AsString(), out aLen ) )
-					{
-						Type t = box.usage.GetNativeTypeFromSerializee( seAT );
-						bool isCilboxElementType = false;
-
-						if (t == null)
-						{
-							// Check the array to see if it is Cilboxed
-							Dictionary<String, Serializee> atMap = seAT.AsMap();
-							String elementTypeName = atMap["n"].AsString();
-							if (box.classes.ContainsKey(elementTypeName))
-							{
-								t = typeof(CilboxProxy);
-								isCilboxElementType = true;
-							}
-							else
-							{
-								oOut = null;
-								return true;
-							}
-						}
-
-						if( !isCilboxElementType && !box.CheckTypeAllowed( t.ToString() ) )
-						{
-							proxyWasSetup = false;
-							throw new Exception( "Contraband ARRAY found in script {className} { cls.instanceFieldNames[i] }" );
-						}
-
-						Array arr = Array.CreateInstance( t, aLen );
-
-						// Hoist AsArray out of the loop — it previously re-parsed seAD and allocated
-						// a fresh Serializee[] of size aLen on every iteration (O(aLen^2) GC).
-						Serializee [] adArr = seAD.AsArray();
-						for( int j = 0; j < aLen; j++ )
-						{
-							object o;
-							LoadObjectFromSerializee( adArr[j], out o, rootFieldName, t, false );
-							arr.SetValue( o, j );
-						}
-
-						oOut = arr;
+						oOut = null;
 						return true;
 					}
 				}
-				else if( sT[0] == 's' || sT[0] == 'e' )
-				{
-					Serializee dsee;
-					if( dict.TryGetValue( "d", out dsee ) )
-					{
-						oOut = CilboxUtil.DeserializeDataForProxyField( inType, dsee.AsString() );
-						return false;
-					}
-				}
-				else if ( sT[0] == 'j' )
-				{
 
-					Serializee seT, seAT, seD;
-					if( dict.TryGetValue( "t", out seT ) &&
-						dict.TryGetValue( "at", out seAT ) &&
-						dict.TryGetValue( "d", out seD ) )
+				if( !isCilboxElementType && !box.CheckTypeAllowed( t.ToString() ) )
+				{
+					proxyWasSetup = false;
+					throw new Exception( $"Contraband ARRAY found in script {className} field {rootFieldName}" );
+				}
+
+				int aLen = spf.arrayElements.Length;
+				Array arr = Array.CreateInstance( t, aLen );
+
+				StackType elementSt = default;
+				bool isPrimArr = !isCilboxElementType
+					&& StackElement.TypeToStackType.TryGetValue(t.ToString(), out elementSt)
+					&& elementSt < StackType.Object;
+
+				if( isPrimArr )
+				{
+					// Typed array fill — one cast outside the loop, direct typed writes inside. Zero boxes.
+					switch( elementSt )
 					{
-						Type t = box.usage.GetNativeTypeFromSerializee( seAT ); // This makes sure we're allowed to have this type.
-						oOut = JsonUtility.FromJson(seD.AsString(), t);
-						return true;
-					}
-					else
-					{
-						Debug.LogWarning( $"Failure to load object in field id:{rootFieldName} of {className}");
+					case StackType.Boolean: { var a = (bool   [])arr; for (int j = 0; j < aLen; j++) a[j] =         spf.arrayElements[j].primitiveValue.b;       break; }
+					case StackType.Sbyte:   { var a = (sbyte  [])arr; for (int j = 0; j < aLen; j++) a[j] = (sbyte )spf.arrayElements[j].primitiveValue.l;       break; }
+					case StackType.Byte:    { var a = (byte   [])arr; for (int j = 0; j < aLen; j++) a[j] = (byte  )spf.arrayElements[j].primitiveValue.e;       break; }
+					case StackType.Short:   { var a = (short  [])arr; for (int j = 0; j < aLen; j++) a[j] = (short )spf.arrayElements[j].primitiveValue.l;       break; }
+					case StackType.Ushort:  { var a = (ushort [])arr; for (int j = 0; j < aLen; j++) a[j] = (ushort)spf.arrayElements[j].primitiveValue.e;       break; }
+					case StackType.Int:     { var a = (int    [])arr; for (int j = 0; j < aLen; j++) a[j] = (int   )spf.arrayElements[j].primitiveValue.l;       break; }
+					case StackType.Uint:    { var a = (uint   [])arr; for (int j = 0; j < aLen; j++) a[j] = (uint  )spf.arrayElements[j].primitiveValue.e;       break; }
+					case StackType.Long:    { var a = (long   [])arr; for (int j = 0; j < aLen; j++) a[j] =         spf.arrayElements[j].primitiveValue.l;       break; }
+					case StackType.Ulong:   { var a = (ulong  [])arr; for (int j = 0; j < aLen; j++) a[j] =         spf.arrayElements[j].primitiveValue.e;       break; }
+					case StackType.Float:   { var a = (float  [])arr; for (int j = 0; j < aLen; j++) a[j] =         spf.arrayElements[j].primitiveValue.f;       break; }
+					case StackType.Double:  { var a = (double [])arr; for (int j = 0; j < aLen; j++) a[j] =         spf.arrayElements[j].primitiveValue.d;       break; }
 					}
 				}
 				else
 				{
-					Debug.LogWarning( $"Unknown field type {sT} on field {rootFieldName}" );
+					for( int j = 0; j < aLen; j++ )
+					{
+						object o;
+						LoadObjectFromProxyField( spf.arrayElements[j], out o, rootFieldName, t );
+						arr.SetValue( o, j );
+					}
 				}
+
+				oOut = arr;
+				return true;
 			}
-			//Debug.Log( $"{i} Output Type:{fields[i].type} Name:{cls.instanceFieldNames[i]} C# field Name:{cls.instanceFieldTypes[i]} Type:{fields[i].type} Value:{((fields[i].type<StackType.Object)?(fields[i].i):(fields[i].o))}" );
+
+			case ProxyFieldType.String:
+			{
+				oOut = spf.data;
+				return false;
+			}
+
+			case ProxyFieldType.Primitive:
+			{
+				// Slow path — only reached if a caller didn't short-circuit. Re-boxes from the
+				// 16-byte PrimitivePayload (no object slot, so the StackElement.AsObject branches
+				// for Address/NativeHandle/Object don't apply here).
+				oOut = spf.primitiveValue.type switch
+				{
+					StackType.Boolean => spf.primitiveValue.b,
+					StackType.Sbyte => (sbyte)spf.primitiveValue.l,
+					StackType.Byte => (byte)spf.primitiveValue.e,
+					StackType.Short => (short)spf.primitiveValue.l,
+					StackType.Ushort => (ushort)spf.primitiveValue.e,
+					StackType.Int => (int)spf.primitiveValue.l,
+					StackType.Uint => (uint)spf.primitiveValue.e,
+					StackType.Long => spf.primitiveValue.l,
+					StackType.Ulong => spf.primitiveValue.e,
+					StackType.Float => spf.primitiveValue.f,
+					StackType.Double => spf.primitiveValue.d,
+					_ => throw new NotSupportedException($"PrimitivePayload cannot box StackType {spf.primitiveValue.type}")
+				};
+				return false;
+			}
+
+			case ProxyFieldType.Json:
+			{
+				Type t = box.usage.GetNativeTypeFromDescriptor( spf.elementType );
+				oOut = JsonUtility.FromJson(spf.data, t);
+				return true;
+			}
+
+			default:
+				break;
+			}
+
 			oOut = null;
 			return false;
 		}

--- a/Packages/com.cnlohr.cilbox/CilboxSerialization.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxSerialization.cs
@@ -1,0 +1,874 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Cilbox
+{
+	public class SerializedTypeDescriptor
+	{
+		public string assemblyName;
+		public string typeName;
+		// Generic fields (present when genericArgs token written)
+		public string genericName;
+		public SerializedTypeDescriptor[] genericArgs;
+		// Underlying type (present when underlyingType token written)
+		public SerializedTypeDescriptor underlyingType;
+
+		public bool IsGeneric => genericArgs != null && genericArgs.Length > 0;
+		public bool HasUnderlyingType => underlyingType != null;
+
+		// Mirrors CilboxUtil.GetSerializeeFromNativeType key order: a, then
+		// (n, gn, g) for generics or (n, [ut]) otherwise.
+		public Serializee ToSerializee()
+		{
+			Dictionary<String, Serializee> ret = new Dictionary<String, Serializee>();
+			ret["a"] = new Serializee( assemblyName );
+			if( IsGeneric )
+			{
+				ret["n"] = new Serializee( typeName );
+				ret["gn"] = new Serializee( genericName );
+				Serializee[] sg = new Serializee[genericArgs.Length];
+				for( int i = 0; i < genericArgs.Length; i++ )
+					sg[i] = genericArgs[i].ToSerializee();
+				ret["g"] = new Serializee( sg );
+			}
+			else
+			{
+				ret["n"] = new Serializee( typeName );
+				if( underlyingType != null )
+					ret["ut"] = underlyingType.ToSerializee();
+			}
+			return new Serializee( ret );
+		}
+
+		public static SerializedTypeDescriptor FromSerializee( Serializee s )
+		{
+			Dictionary<String, Serializee> m = s.AsMap();
+			SerializedTypeDescriptor td = new SerializedTypeDescriptor();
+			td.assemblyName = m["a"].AsString();
+			td.typeName = m["n"].AsString();
+			if( m.TryGetValue( "g", out Serializee g ) )
+			{
+				td.genericName = m["gn"].AsString();
+				Serializee[] ga = g.AsArray();
+				td.genericArgs = new SerializedTypeDescriptor[ga.Length];
+				for( int i = 0; i < ga.Length; i++ )
+					td.genericArgs[i] = FromSerializee( ga[i] );
+			}
+			if( m.TryGetValue( "ut", out Serializee ut ) )
+				td.underlyingType = FromSerializee( ut );
+			return td;
+		}
+	}
+
+	public class SerializedField
+	{
+		public string name;
+		public SerializedTypeDescriptor type;
+
+		// The same struct is serialized with two different type-key schemes:
+		//  - class fields use "type"
+		//  - method locals / parameters use "dt"
+		private Serializee ToSerializeeWithTypeKey( String typeKey )
+		{
+			Dictionary<String, Serializee> ret = new Dictionary<String, Serializee>();
+			ret["name"] = new Serializee( name );
+			ret[typeKey] = type.ToSerializee();
+			return new Serializee( ret );
+		}
+
+		public Serializee ToClassFieldSerializee() => ToSerializeeWithTypeKey( "type" );
+		public Serializee ToMethodFieldSerializee() => ToSerializeeWithTypeKey( "dt" );
+
+		private static SerializedField FromSerializeeWithTypeKey( Serializee s, String typeKey )
+		{
+			Dictionary<String, Serializee> m = s.AsMap();
+			SerializedField f = new SerializedField();
+			f.name = m["name"].AsString();
+			f.type = SerializedTypeDescriptor.FromSerializee( m[typeKey] );
+			return f;
+		}
+
+		public static SerializedField FromClassFieldSerializee( Serializee s ) => FromSerializeeWithTypeKey( s, "type" );
+		public static SerializedField FromMethodFieldSerializee( Serializee s ) => FromSerializeeWithTypeKey( s, "dt" );
+	}
+
+	public class SerializedExceptionHandler
+	{
+		public int flags;
+		public int tryOffset;
+		public int tryLength;
+		public int handlerOffset;
+		public int handlerLength;
+		public bool hasCatchType;
+		public SerializedTypeDescriptor catchType;
+
+		public Serializee ToSerializee()
+		{
+			Dictionary<String, Serializee> ret = new Dictionary<String, Serializee>();
+			ret["flags"] = new Serializee( flags.ToString() );
+			ret["tryOff"] = new Serializee( tryOffset.ToString() );
+			ret["tryLen"] = new Serializee( tryLength.ToString() );
+			ret["hOff"] = new Serializee( handlerOffset.ToString() );
+			ret["hLen"] = new Serializee( handlerLength.ToString() );
+			if( hasCatchType )
+				ret["cType"] = catchType.ToSerializee();
+			return new Serializee( ret );
+		}
+
+		public static SerializedExceptionHandler FromSerializee( Serializee s )
+		{
+			Dictionary<String, Serializee> m = s.AsMap();
+			SerializedExceptionHandler eh = new SerializedExceptionHandler();
+			eh.flags = Int32.Parse( m["flags"].AsString() );
+			eh.tryOffset = Int32.Parse( m["tryOff"].AsString() );
+			eh.tryLength = Int32.Parse( m["tryLen"].AsString() );
+			eh.handlerOffset = Int32.Parse( m["hOff"].AsString() );
+			eh.handlerLength = Int32.Parse( m["hLen"].AsString() );
+			if( m.TryGetValue( "cType", out Serializee cType ) )
+			{
+				eh.hasCatchType = true;
+				eh.catchType = SerializedTypeDescriptor.FromSerializee( cType );
+			}
+			return eh;
+		}
+	}
+
+	public class SerializedMethod
+	{
+		public string methodName;
+		public int maxStack;
+		public bool isVoid;
+		public bool isStatic;
+		public bool isCtor;
+		public string fullSignature;
+		public byte[] body;
+		public SerializedField[] locals;
+		public SerializedField[] parameters;
+		public SerializedExceptionHandler[] exceptionHandlers;
+
+		// methodName is the enclosing Map key, not part of this map.
+		// Master MethodProps order: body, [eh], locals, parameters, maxStack,
+		// isVoid, isCtor, isStatic, fullSignature.
+		public Serializee ToSerializee()
+		{
+			Dictionary<String, Serializee> ret = new Dictionary<String, Serializee>();
+			ret["body"] = Serializee.CreateFromBlob( body );
+
+			if( exceptionHandlers != null && exceptionHandlers.Length > 0 )
+			{
+				Serializee[] eh = new Serializee[exceptionHandlers.Length];
+				for( int i = 0; i < exceptionHandlers.Length; i++ )
+					eh[i] = exceptionHandlers[i].ToSerializee();
+				ret["eh"] = new Serializee( eh );
+			}
+
+			Serializee[] loc = new Serializee[locals.Length];
+			for( int i = 0; i < locals.Length; i++ )
+				loc[i] = locals[i].ToMethodFieldSerializee();
+			ret["locals"] = new Serializee( loc );
+
+			Serializee[] par = new Serializee[parameters.Length];
+			for( int i = 0; i < parameters.Length; i++ )
+				par[i] = parameters[i].ToMethodFieldSerializee();
+			ret["parameters"] = new Serializee( par );
+
+			ret["maxStack"] = new Serializee( maxStack.ToString() );
+			ret["isVoid"] = new Serializee( isVoid ? "1" : "0" );
+			ret["isCtor"] = new Serializee( isCtor ? "1" : "0" );
+			ret["isStatic"] = new Serializee( isStatic ? "1" : "0" );
+			ret["name"] = new Serializee( methodName );
+			ret["fullSignature"] = new Serializee( fullSignature );
+			return new Serializee( ret );
+		}
+
+		public static SerializedMethod FromSerializee( Serializee s, String methodName )
+		{
+			Dictionary<String, Serializee> m = s.AsMap();
+			SerializedMethod sm = new SerializedMethod();
+			sm.methodName = methodName;
+			sm.body = m["body"].AsBlob();
+
+			if( m.TryGetValue( "eh", out Serializee ehS ) )
+			{
+				Serializee[] eh = ehS.AsArray();
+				sm.exceptionHandlers = new SerializedExceptionHandler[eh.Length];
+				for( int i = 0; i < eh.Length; i++ )
+					sm.exceptionHandlers[i] = SerializedExceptionHandler.FromSerializee( eh[i] );
+			}
+			else
+			{
+				sm.exceptionHandlers = new SerializedExceptionHandler[0];
+			}
+
+			Serializee[] loc = m["locals"].AsArray();
+			sm.locals = new SerializedField[loc.Length];
+			for( int i = 0; i < loc.Length; i++ )
+				sm.locals[i] = SerializedField.FromMethodFieldSerializee( loc[i] );
+
+			Serializee[] par = m["parameters"].AsArray();
+			sm.parameters = new SerializedField[par.Length];
+			for( int i = 0; i < par.Length; i++ )
+				sm.parameters[i] = SerializedField.FromMethodFieldSerializee( par[i] );
+
+			sm.maxStack = Int32.Parse( m["maxStack"].AsString() );
+			sm.isVoid = Int32.Parse( m["isVoid"].AsString() ) != 0;
+			sm.isCtor = Int32.Parse( m["isCtor"].AsString() ) != 0;
+			sm.isStatic = Int32.Parse( m["isStatic"].AsString() ) != 0;
+			sm.fullSignature = m["fullSignature"].AsString();
+			if (m.TryGetValue( "name", out Serializee nameS))
+			{
+				sm.methodName = nameS.AsString();
+			}
+			return sm;
+		}
+	}
+
+	public class SerializedClass
+	{
+		public string className;
+		public SerializedField[] staticFields;
+		public SerializedField[] instanceFields;
+		public SerializedMethod[] methods;
+		public string[] baseClassNames;
+
+		// className is the enclosing Map key. Master classProps order:
+		// staticFields, instanceFields, methods (methods is a Map keyed by
+		// method name, which collapses overloads to last-value/first-position).
+		public Serializee ToSerializee()
+		{
+			Dictionary<String, Serializee> ret = new Dictionary<String, Serializee>();
+
+			Serializee[] sf = new Serializee[staticFields.Length];
+			for( int i = 0; i < staticFields.Length; i++ )
+				sf[i] = staticFields[i].ToClassFieldSerializee();
+			ret["staticFields"] = new Serializee( sf );
+
+			Serializee[] inf = new Serializee[instanceFields.Length];
+			for( int i = 0; i < instanceFields.Length; i++ )
+				inf[i] = instanceFields[i].ToClassFieldSerializee();
+			ret["instanceFields"] = new Serializee( inf );
+
+			Dictionary<String, Serializee> mm = new Dictionary<String, Serializee>();
+			for( int i = 0; i < methods.Length; i++ )
+				mm[methods[i].fullSignature] = methods[i].ToSerializee();
+			ret["methods"] = new Serializee( mm );
+
+			List<Serializee> bcn = new List<Serializee>();
+			foreach (string bc in baseClassNames)
+			{
+				bcn.Add(new Serializee(bc));
+			}
+			ret["baseClasses"] = new Serializee(bcn.ToArray());
+
+			return new Serializee( ret );
+		}
+
+		public static SerializedClass FromSerializee( Serializee s, String className )
+		{
+			Dictionary<String, Serializee> m = s.AsMap();
+			SerializedClass sc = new SerializedClass();
+			sc.className = className;
+
+			Serializee[] sf = m["staticFields"].AsArray();
+			sc.staticFields = new SerializedField[sf.Length];
+			for( int i = 0; i < sf.Length; i++ )
+				sc.staticFields[i] = SerializedField.FromClassFieldSerializee( sf[i] );
+
+			Serializee[] inf = m["instanceFields"].AsArray();
+			sc.instanceFields = new SerializedField[inf.Length];
+			for( int i = 0; i < inf.Length; i++ )
+				sc.instanceFields[i] = SerializedField.FromClassFieldSerializee( inf[i] );
+
+			Dictionary<String, Serializee> mm = m["methods"].AsMap();
+			sc.methods = new SerializedMethod[mm.Count];
+			int mi = 0;
+			foreach( KeyValuePair<String, Serializee> kv in mm )
+				sc.methods[mi++] = SerializedMethod.FromSerializee( kv.Value, kv.Key );
+
+			if (m.TryGetValue("baseClasses", out Serializee baseClassesSer))
+			{
+				Serializee [] bcArr = baseClassesSer.AsArray();
+				sc.baseClassNames = new String[bcArr.Length];
+				for( int bci = 0; bci < bcArr.Length; bci++ )
+					sc.baseClassNames[bci] = bcArr[bci].AsString();
+			}
+			else
+			{
+				sc.baseClassNames = new String[0];
+			}
+
+			return sc;
+		}
+	}
+
+	/// <summary>
+	/// Metadata token — discriminated union keyed by MetaTokenType.
+	/// Stored in a flat array indexed by (integer token - 1).
+	/// </summary>
+	public class SerializedMetadataToken
+	{
+		public byte metaTokenType; // MetaTokenType enum value
+
+		// mtString
+		public string stringValue;
+
+		// mtArrayInitializer
+		public byte[] arrayInitData;
+
+		// mtField
+		public SerializedTypeDescriptor fieldDeclaringType;
+		public string fieldName;
+		public bool fieldIsStatic;
+		public bool fieldHasIndex;
+		public int fieldIndex;
+
+		// mtType
+		public SerializedTypeDescriptor typeDescriptor;
+
+		// mtMethod
+		public SerializedTypeDescriptor methodDeclaringType;
+		public string methodName;
+		public string methodFullSignature;
+		public bool methodIsStatic;
+		public string methodAssembly;
+		public SerializedTypeDescriptor[] methodParameters;
+		public SerializedTypeDescriptor[] methodGenericArguments;
+
+		public Serializee ToSerializee()
+		{
+			Dictionary<String, Serializee> ret = new Dictionary<String, Serializee>();
+			MetaTokenType mt = (MetaTokenType)metaTokenType;
+			String mtStr = ((int)metaTokenType).ToString();
+
+			switch( mt )
+			{
+				case MetaTokenType.mtArrayInitializer:
+					ret["mt"] = new Serializee( mtStr );
+					ret["data"] = Serializee.CreateFromBlob( arrayInitData );
+					break;
+				case MetaTokenType.mtString:
+					ret["mt"] = new Serializee( mtStr );
+					ret["s"] = new Serializee( stringValue );
+					break;
+				case MetaTokenType.mtMethod:
+					// Master order: [ga], dt, name, [parameters], fullSignature,
+					// isStatic, assembly, mt (mt is written LAST for methods).
+					if( methodGenericArguments != null && methodGenericArguments.Length > 0 )
+					{
+						Serializee[] ga = new Serializee[methodGenericArguments.Length];
+						for( int i = 0; i < methodGenericArguments.Length; i++ )
+							ga[i] = methodGenericArguments[i].ToSerializee();
+						ret["ga"] = new Serializee( ga );
+					}
+					ret["dt"] = methodDeclaringType.ToSerializee();
+					ret["name"] = new Serializee( methodName );
+					if( methodParameters != null && methodParameters.Length > 0 )
+					{
+						Serializee[] par = new Serializee[methodParameters.Length];
+						for( int i = 0; i < methodParameters.Length; i++ )
+							par[i] = methodParameters[i].ToSerializee();
+						ret["parameters"] = new Serializee( par );
+					}
+					ret["fullSignature"] = new Serializee( methodFullSignature );
+					ret["isStatic"] = new Serializee( methodIsStatic ? "1" : "0" );
+					ret["assembly"] = new Serializee( methodAssembly );
+					ret["mt"] = new Serializee( mtStr );
+					break;
+				case MetaTokenType.mtField:
+					// Master order: mt, dt, name, isStatic, [index] (index appended last).
+					ret["mt"] = new Serializee( mtStr );
+					ret["dt"] = fieldDeclaringType.ToSerializee();
+					ret["name"] = new Serializee( fieldName );
+					ret["isStatic"] = new Serializee( fieldIsStatic ? "1" : "0" );
+					if( fieldHasIndex )
+						ret["index"] = new Serializee( fieldIndex.ToString() );
+					break;
+				case MetaTokenType.mtType:
+					ret["mt"] = new Serializee( mtStr );
+					ret["dt"] = typeDescriptor.ToSerializee();
+					break;
+			}
+			return new Serializee( ret );
+		}
+
+		public static SerializedMetadataToken FromSerializee( Serializee s )
+		{
+			Dictionary<String, Serializee> m = s.AsMap();
+			SerializedMetadataToken t = new SerializedMetadataToken();
+			t.metaTokenType = (byte)Int32.Parse( m["mt"].AsString() );
+			MetaTokenType mt = (MetaTokenType)t.metaTokenType;
+
+			switch( mt )
+			{
+				case MetaTokenType.mtArrayInitializer:
+					t.arrayInitData = m["data"].AsBlob();
+					break;
+				case MetaTokenType.mtString:
+					t.stringValue = m["s"].AsString();
+					break;
+				case MetaTokenType.mtMethod:
+					t.methodDeclaringType = SerializedTypeDescriptor.FromSerializee( m["dt"] );
+					t.methodName = m["name"].AsString();
+					t.methodFullSignature = m["fullSignature"].AsString();
+					t.methodIsStatic = Int32.Parse( m["isStatic"].AsString() ) != 0;
+					t.methodAssembly = m["assembly"].AsString();
+					if( m.TryGetValue( "parameters", out Serializee parS ) )
+					{
+						Serializee[] par = parS.AsArray();
+						t.methodParameters = new SerializedTypeDescriptor[par.Length];
+						for( int i = 0; i < par.Length; i++ )
+							t.methodParameters[i] = SerializedTypeDescriptor.FromSerializee( par[i] );
+					}
+					else
+					{
+						t.methodParameters = new SerializedTypeDescriptor[0];
+					}
+					if( m.TryGetValue( "ga", out Serializee gaS ) )
+					{
+						Serializee[] ga = gaS.AsArray();
+						t.methodGenericArguments = new SerializedTypeDescriptor[ga.Length];
+						for( int i = 0; i < ga.Length; i++ )
+							t.methodGenericArguments[i] = SerializedTypeDescriptor.FromSerializee( ga[i] );
+					}
+					else
+					{
+						t.methodGenericArguments = new SerializedTypeDescriptor[0];
+					}
+					break;
+				case MetaTokenType.mtField:
+					t.fieldDeclaringType = SerializedTypeDescriptor.FromSerializee( m["dt"] );
+					t.fieldName = m["name"].AsString();
+					t.fieldIsStatic = Int32.Parse( m["isStatic"].AsString() ) != 0;
+					if( m.TryGetValue( "index", out Serializee idx ) )
+					{
+						t.fieldHasIndex = true;
+						t.fieldIndex = Int32.Parse( idx.AsString() );
+					}
+					break;
+				case MetaTokenType.mtType:
+					t.typeDescriptor = SerializedTypeDescriptor.FromSerializee( m["dt"] );
+					break;
+			}
+			return t;
+		}
+	}
+
+	public class SerializedEnumValue
+	{
+		public string name;
+		public long value;
+
+		public Serializee ToSerializee()
+		{
+			Dictionary<String, Serializee> ret = new Dictionary<String, Serializee>();
+			ret["n"] = new Serializee( name );
+			ret["v"] = new Serializee( value.ToString() );
+			return new Serializee( ret );
+		}
+
+		public static SerializedEnumValue FromSerializee( Serializee s )
+		{
+			Dictionary<String, Serializee> m = s.AsMap();
+			SerializedEnumValue v = new SerializedEnumValue();
+			v.name = m["n"].AsString();
+			v.value = Int64.Parse( m["v"].AsString() );
+			return v;
+		}
+	}
+
+	public class SerializedEnum
+	{
+		public string enumName;
+		public SerializedTypeDescriptor underlyingType;
+		public SerializedEnumValue[] values;
+
+		// enumName is the enclosing Map key. Master enumProps order: ut, values.
+		public Serializee ToSerializee()
+		{
+			Dictionary<String, Serializee> ret = new Dictionary<String, Serializee>();
+			ret["ut"] = underlyingType.ToSerializee();
+			Serializee[] vals = new Serializee[values.Length];
+			for( int i = 0; i < values.Length; i++ )
+				vals[i] = values[i].ToSerializee();
+			ret["values"] = new Serializee( vals );
+			return new Serializee( ret );
+		}
+
+		public static SerializedEnum FromSerializee( Serializee s, String enumName )
+		{
+			Dictionary<String, Serializee> m = s.AsMap();
+			SerializedEnum e = new SerializedEnum();
+			e.enumName = enumName;
+			e.underlyingType = SerializedTypeDescriptor.FromSerializee( m["ut"] );
+			Serializee[] vals = m["values"].AsArray();
+			e.values = new SerializedEnumValue[vals.Length];
+			for( int i = 0; i < vals.Length; i++ )
+				e.values[i] = SerializedEnumValue.FromSerializee( vals[i] );
+			return e;
+		}
+	}
+
+	public class SerializedAssembly
+	{
+		public SerializedClass[] classes;
+		public SerializedMetadataToken[] metadata; // 0-based; token N lives at index N-1
+		public SerializedEnum[] enums;
+
+		// Root Map order: classes (keyed className), metadata (keyed by string
+		// token index starting at 1), enums (keyed enumName). base64 of the
+		// Serializee buffer, byte-for-byte identical to master's assemblyData.
+		public string Serialize()
+		{
+			Dictionary<String, Serializee> root = new Dictionary<String, Serializee>();
+
+			Dictionary<String, Serializee> cl = new Dictionary<String, Serializee>();
+			for( int i = 0; i < classes.Length; i++ )
+				cl[classes[i].className] = classes[i].ToSerializee();
+			root["classes"] = new Serializee( cl );
+
+			Dictionary<String, Serializee> md = new Dictionary<String, Serializee>();
+			for( int i = 0; i < metadata.Length; i++ )
+				md[(i + 1).ToString()] = metadata[i].ToSerializee();
+			root["metadata"] = new Serializee( md );
+
+			Dictionary<String, Serializee> en = new Dictionary<String, Serializee>();
+			for( int i = 0; i < enums.Length; i++ )
+				en[enums[i].enumName] = enums[i].ToSerializee();
+			root["enums"] = new Serializee( en );
+
+			return Convert.ToBase64String( new Serializee( root ).DumpAsMemory().ToArray() );
+		}
+
+		public static SerializedAssembly Deserialize( string base64 )
+		{
+			SerializedAssembly asm = new SerializedAssembly();
+			Dictionary<String, Serializee> root =
+				new Serializee( Convert.FromBase64String( base64 ), Serializee.ElementType.Map ).AsMap();
+
+			Dictionary<String, Serializee> cl = root["classes"].AsMap();
+			asm.classes = new SerializedClass[cl.Count];
+			int ci = 0;
+			foreach( KeyValuePair<String, Serializee> kv in cl )
+				asm.classes[ci++] = SerializedClass.FromSerializee( kv.Value, kv.Key );
+
+			Dictionary<String, Serializee> md = root["metadata"].AsMap();
+			asm.metadata = new SerializedMetadataToken[md.Count];
+			foreach( KeyValuePair<String, Serializee> kv in md )
+				asm.metadata[Int32.Parse( kv.Key ) - 1] = SerializedMetadataToken.FromSerializee( kv.Value );
+
+			if( root.TryGetValue( "enums", out Serializee enumsS ) )
+			{
+				Dictionary<String, Serializee> en = enumsS.AsMap();
+				asm.enums = new SerializedEnum[en.Count];
+				int ei = 0;
+				foreach( KeyValuePair<String, Serializee> kv in en )
+					asm.enums[ei++] = SerializedEnum.FromSerializee( kv.Value, kv.Key );
+			}
+			else
+			{
+				asm.enums = new SerializedEnum[0];
+			}
+
+			return asm;
+		}
+	}
+
+	/// <summary>
+	/// Helper to build a SerializedTypeDescriptor from a native System.Type.
+	/// Used by the editor compiler to build type descriptors from native System.Type.
+	/// </summary>
+	public static class SerializedTypeDescriptorBuilder
+	{
+		public static SerializedTypeDescriptor FromNativeType(Type t)
+		{
+			var td = new SerializedTypeDescriptor();
+			td.assemblyName = t.Assembly.GetName().Name;
+
+			if (t.IsGenericType)
+			{
+				string genericDefName = t.GetGenericTypeDefinition().FullName;
+				// Strip arity markers (`1, `2) from the generic definition name
+				var sb = new StringBuilder();
+				for (int i = 0; i < genericDefName.Length; i++)
+				{
+					if (genericDefName[i] != '`')
+					{
+						sb.Append(genericDefName[i]);
+						continue;
+					}
+
+					int j = i + 1;
+					while (j < genericDefName.Length && char.IsDigit(genericDefName[j]))
+						j++;
+					if (j == genericDefName.Length || genericDefName[j] == '+' || genericDefName[j] == '[')
+						i = j - 1;
+				}
+				td.typeName = sb.ToString();
+				td.genericName = genericDefName;
+				Type[] ta = t.GenericTypeArguments;
+				td.genericArgs = new SerializedTypeDescriptor[ta.Length];
+				for (int i = 0; i < ta.Length; i++)
+					td.genericArgs[i] = FromNativeType(ta[i]);
+			}
+			else
+			{
+				td.typeName = t.FullName;
+				if (t.IsEnum && CilboxUtil.HasCilboxableAttribute(t))
+					td.underlyingType = FromNativeType(t.GetEnumUnderlyingType());
+			}
+			return td;
+		}
+	}
+
+	public enum ProxyFieldType : byte
+	{
+		Empty       = 0,  // null field
+		String      = 1,  // "s"
+		Primitive   = 2,  // "e<StackType>" — primitives and enums
+		CilboxRef   = 3,  // "cba" — Cilboxable object reference
+		ObjectRef   = 4,  // "obj" — UnityEngine.Object reference
+		Array       = 5,  // "a"
+		Json        = 6,  // "j" — JsonUtility-serialized struct
+	}
+
+	// Primitive-only value payload. 16 bytes (no object slot). NOTE: keep the
+	// value-slot field offsets in lockstep with StackElement (offset 8, same
+	// union layout) - the consume site copies the 8-byte `l` slot directly into
+	// StackElement.l, relying on identical bit layout for b/f/d/l/e.
+	[StructLayout(LayoutKind.Explicit)]
+	public struct PrimitivePayload
+	{
+		[FieldOffset(0)] public StackType type;
+		[FieldOffset(8)] public bool   b;
+		[FieldOffset(8)] public float  f;
+		[FieldOffset(8)] public double d;
+		[FieldOffset(8)] public long   l;
+		[FieldOffset(8)] public ulong  e;
+
+		public void Unbox( object i, StackType st )
+		{
+			type = st;
+			switch( st )
+			{
+				case StackType.Boolean: this.l = ((bool)i)?1:0; break;
+				case StackType.Sbyte:   this.l = (sbyte)i;      break;
+				case StackType.Byte:    this.e = (byte)i;       break;
+				case StackType.Short:   this.l = (short)i;      break;
+				case StackType.Ushort:  this.e = (ushort)i;     break;
+				case StackType.Int:     this.l = (int)i;        break;
+				case StackType.Uint:    this.e = (uint)i;       break;
+				case StackType.Long:    this.l = (long)i;       break;
+				case StackType.Ulong:   this.e = (ulong)i;      break;
+				case StackType.Float:   this.l = 0; this.f = (float)i;  break;
+				case StackType.Double:  this.d = (double)i;     break;
+			}
+		}
+	}
+
+	public class SerializedProxyField
+	{
+		public byte fieldType;            // ProxyFieldType
+		public string fieldName;          // null for non-root (array elements)
+		public int matchingInstanceId;    // -1 for non-root
+
+		// String / Json
+		public string data;               // value as string / JSON text
+		// Primitive
+		public PrimitivePayload primitiveValue;  // primitiveValue.type holds the StackType
+
+		// CilboxRef / ObjectRef
+		public int fieldObjectIndex;      // index into fieldsObjects
+		public bool objectRefIsNull;      // true when the original ref was null
+		public string objectRefName;      // fv.ToString() of the referenced object
+
+		// Array / Json
+		public SerializedTypeDescriptor elementType;
+
+		// Array (recursive)
+		public SerializedProxyField[] arrayElements;
+
+		private static String PrimitiveToString( in PrimitivePayload v )
+		{
+			switch( v.type )
+			{
+				case StackType.Boolean: return v.b.ToString();
+				case StackType.Sbyte:   return ((sbyte)v.l).ToString();
+				case StackType.Byte:    return ((byte)v.e).ToString();
+				case StackType.Short:   return ((short)v.l).ToString();
+				case StackType.Ushort:  return ((ushort)v.e).ToString();
+				case StackType.Int:     return ((int)v.l).ToString();
+				case StackType.Uint:    return ((uint)v.e).ToString();
+				case StackType.Long:    return v.l.ToString();
+				case StackType.Ulong:   return v.e.ToString();
+				case StackType.Float:   return v.f.ToString();
+				case StackType.Double:  return v.d.ToString();
+				default: throw new CilboxException( $"Unknown primitive StackType {v.type}" );
+			}
+		}
+
+		private static PrimitivePayload PrimitiveFromString( String d, StackType st )
+		{
+			PrimitivePayload v = default;
+			v.type = st;
+			switch( st )
+			{
+				case StackType.Boolean: v.l = bool.Parse( d ) ? 1 : 0; break;
+				case StackType.Sbyte:   v.l = sbyte.Parse( d );        break;
+				case StackType.Byte:    v.e = byte.Parse( d );         break;
+				case StackType.Short:   v.l = short.Parse( d );        break;
+				case StackType.Ushort:  v.e = ushort.Parse( d );       break;
+				case StackType.Int:     v.l = int.Parse( d );          break;
+				case StackType.Uint:    v.e = uint.Parse( d );         break;
+				case StackType.Long:    v.l = long.Parse( d );         break;
+				case StackType.Ulong:   v.e = ulong.Parse( d );        break;
+				case StackType.Float:   v.l = 0; v.f = float.Parse( d ); break;
+				case StackType.Double:  v.d = double.Parse( d );       break;
+				default: throw new CilboxException( $"Unknown primitive StackType {st}" );
+			}
+			return v;
+		}
+
+		// Mirrors CilboxProxy.SerializeThing. Empty fields emit ONLY {empty:"true"}.
+		// Otherwise: [n], [miid], then type-specific keys in master's exact order.
+		public Serializee ToSerializee()
+		{
+			Dictionary<String, Serializee> f = new Dictionary<String, Serializee>();
+
+			if( (ProxyFieldType)fieldType == ProxyFieldType.Empty )
+			{
+				f["empty"] = new Serializee( "true" );
+				return new Serializee( f );
+			}
+
+			if( fieldName != null )
+				f["n"] = new Serializee( fieldName );
+			if( matchingInstanceId >= 0 )
+				f["miid"] = new Serializee( matchingInstanceId.ToString() );
+
+			switch( (ProxyFieldType)fieldType )
+			{
+				case ProxyFieldType.String:
+					f["d"] = new Serializee( data );
+					f["t"] = new Serializee( "s" );
+					break;
+				case ProxyFieldType.Primitive:
+					f["d"] = new Serializee( PrimitiveToString( primitiveValue ) );
+					f["t"] = new Serializee( "e" + primitiveValue.type );
+					break;
+				case ProxyFieldType.CilboxRef:
+					f["fo"] = new Serializee( fieldObjectIndex.ToString() );
+					f["t"] = new Serializee( "cba" );
+					f["or"] = new Serializee( objectRefName );
+					break;
+				case ProxyFieldType.ObjectRef:
+					f["fo"] = new Serializee( fieldObjectIndex.ToString() );
+					f["t"] = new Serializee( "obj" );
+					f["or"] = new Serializee( objectRefName );
+					break;
+				case ProxyFieldType.Array:
+					f["t"] = new Serializee( "a" );
+					f["at"] = elementType.ToSerializee();
+					f["al"] = new Serializee( arrayElements.Length.ToString() );
+					Serializee[] ad = new Serializee[arrayElements.Length];
+					for( int i = 0; i < arrayElements.Length; i++ )
+						ad[i] = arrayElements[i].ToSerializee();
+					f["ad"] = new Serializee( ad );
+					break;
+				case ProxyFieldType.Json:
+					f["t"] = new Serializee( "j" );
+					f["d"] = new Serializee( data );
+					f["at"] = elementType.ToSerializee();
+					break;
+			}
+			return new Serializee( f );
+		}
+
+		public static SerializedProxyField FromSerializee( Serializee s )
+		{
+			Dictionary<String, Serializee> m = s.AsMap();
+			SerializedProxyField f = new SerializedProxyField();
+			f.matchingInstanceId = -1;
+
+			if( m.ContainsKey( "empty" ) )
+			{
+				f.fieldType = (byte)ProxyFieldType.Empty;
+				return f;
+			}
+
+			if( m.TryGetValue( "n", out Serializee nS ) )
+				f.fieldName = nS.AsString();
+			if( m.TryGetValue( "miid", out Serializee miidS ) )
+				f.matchingInstanceId = Int32.Parse( miidS.AsString() );
+
+			String t = m["t"].AsString();
+			if( t == "s" )
+			{
+				f.fieldType = (byte)ProxyFieldType.String;
+				f.data = m["d"].AsString();
+			}
+			else if( t == "cba" )
+			{
+				f.fieldType = (byte)ProxyFieldType.CilboxRef;
+				f.fieldObjectIndex = Int32.Parse( m["fo"].AsString() );
+				f.objectRefName = m["or"].AsString();
+				f.objectRefIsNull = f.objectRefName == "null";
+			}
+			else if( t == "obj" )
+			{
+				f.fieldType = (byte)ProxyFieldType.ObjectRef;
+				f.fieldObjectIndex = Int32.Parse( m["fo"].AsString() );
+				f.objectRefName = m["or"].AsString();
+				f.objectRefIsNull = f.objectRefName == "null";
+			}
+			else if( t == "a" )
+			{
+				f.fieldType = (byte)ProxyFieldType.Array;
+				f.elementType = SerializedTypeDescriptor.FromSerializee( m["at"] );
+				Serializee[] ad = m["ad"].AsArray();
+				f.arrayElements = new SerializedProxyField[ad.Length];
+				for( int i = 0; i < ad.Length; i++ )
+					f.arrayElements[i] = FromSerializee( ad[i] );
+			}
+			else if( t == "j" )
+			{
+				f.fieldType = (byte)ProxyFieldType.Json;
+				f.data = m["d"].AsString();
+				f.elementType = SerializedTypeDescriptor.FromSerializee( m["at"] );
+			}
+			else if( t.Length > 0 && t[0] == 'e' )
+			{
+				f.fieldType = (byte)ProxyFieldType.Primitive;
+				StackType st = (StackType)Enum.Parse( typeof(StackType), t.Substring(1) );
+				f.primitiveValue = PrimitiveFromString( m["d"].AsString(), st );
+			}
+			return f;
+		}
+	}
+
+	public class SerializedProxy
+	{
+		public SerializedProxyField[] fields;
+
+		// Root is a List of per-field Maps, base64-encoded — identical to
+		// master's serializedObjectData.
+		public string Serialize()
+		{
+			Serializee[] arr = new Serializee[fields.Length];
+			for( int i = 0; i < fields.Length; i++ )
+				arr[i] = fields[i].ToSerializee();
+			return Convert.ToBase64String( new Serializee( arr ).DumpAsMemory().ToArray() );
+		}
+
+		public static SerializedProxy Deserialize( string base64 )
+		{
+			SerializedProxy p = new SerializedProxy();
+			Serializee[] arr = new Serializee( Convert.FromBase64String( base64 ), Serializee.ElementType.Map ).AsArray();
+			p.fields = new SerializedProxyField[arr.Length];
+			for( int i = 0; i < arr.Length; i++ )
+				p.fields[i] = SerializedProxyField.FromSerializee( arr[i] );
+			return p;
+		}
+	}
+}

--- a/Packages/com.cnlohr.cilbox/CilboxSerialization.cs.meta
+++ b/Packages/com.cnlohr.cilbox/CilboxSerialization.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a2cce3ccd1c12bf4ebb6f5de53bd0000

--- a/Packages/com.cnlohr.cilbox/CilboxUsage.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxUsage.cs
@@ -6,7 +6,7 @@
 // Security Checking:
 //   For Methods:
 //     1. HandleEarlyMethodRewrite() -- This can rewrite declaring type + method.
-//     2. GetNativeTypeNameFromSerializee on declaring type
+//     2. GetNativeTypeNameFromDescriptor on declaring type
 //     3. GetNativeMethodFromTypeAndName - Sometimes swap-out stuff
 //        a. If rewritten, overrides all further security and fast-paths.
 //     4. InternalGetNativeMethodFromTypeAndNameNoSecurity
@@ -17,14 +17,14 @@
 //     8. If disallowed, abort.  If allowed, and overridden, bypass any further checks.
 //
 //
-//   GetNativeTypeFromSerializee (can only be used on non-templated types)
+//   GetNativeTypeFromDescriptor (can only be used on non-templated types)
 //     1. Checks to see if it's a type from within this cilbox.  If so GO!
 //     2. CheckReplaceTypeNotRecursive ON BASE TYPE ONLY
-//     3. Recursively check all template types through GetNativeTypeFromSerializee
+//     3. Recursively check all template types through GetNativeTypeFromDescriptor
 //     4. Type.GetType
 //     5. MakeGenericType
 //
-//   GetNativeTypeNameFromSerializee mimics GetNativeTypeFromSerializee
+//   GetNativeTypeNameFromDescriptor mimics GetNativeTypeFromDescriptor
 //
 //   CheckTypeSecurity calls CheckTypeAllowed on the specific cilbox.
 //    If it is allowed, continue normal checks.  If it is disallowed, abort.
@@ -60,7 +60,7 @@ namespace Cilbox
 			return false;
 		}
 
-		public MethodBase GetNativeMethodFromTypeAndName( Type declaringType, String name, Serializee [] parametersIn, Serializee [] genericArgumentsIn, String fullSignature )
+		public MethodBase GetNativeMethodFromTypeAndName( Type declaringType, String name, SerializedTypeDescriptor [] parametersIn, SerializedTypeDescriptor [] genericArgumentsIn, String fullSignature )
 		{
 			MethodInfo mi = null;
 			if(!box.CheckMethodAllowed( out mi, declaringType, name, parametersIn, genericArgumentsIn, fullSignature ))
@@ -80,8 +80,8 @@ namespace Cilbox
 				return mi;
 			}
 
-			Type[] parameters = TypeNamesToArrayOfNativeTypes( parametersIn );
-			Type[] genericArguments = TypeNamesToArrayOfNativeTypes( genericArgumentsIn );
+			Type[] parameters = DescriptorsToArrayOfNativeTypes( parametersIn );
+			Type[] genericArguments = DescriptorsToArrayOfNativeTypes( genericArgumentsIn );
 
 			MethodBase m = InternalGetNativeMethodFromTypeAndNameNoSecurity( declaringType, name, parameters, genericArguments, fullSignature );
 
@@ -90,7 +90,7 @@ namespace Cilbox
 			{
 				if( !CheckTypeSecurityRecursive(parameters[i]) )
 				{
-                    string typeName = genericArgumentsIn[i].AsMap()["n"].AsString();
+					string typeName = parametersIn[i].typeName;
 					Debug.LogError( $"Privilege failed for {declaringType}.{name} parameter {i} type {typeName}" );
 					return null;
 				}
@@ -99,7 +99,7 @@ namespace Cilbox
 			{
 				if( !CheckTypeSecurityRecursive(genericArguments[i]) )
 				{
-                    string typeName = genericArgumentsIn[i].AsMap()["n"].AsString();
+					string typeName = genericArgumentsIn[i].typeName;
 					Debug.LogError( $"Privilege failed for {declaringType}.{name} generic argument {i} type {typeName}" );
 					return null;
 				}
@@ -247,10 +247,9 @@ namespace Cilbox
 		// REWRITERS ///////////////////////////////////////////////////////////////////////
 		////////////////////////////////////////////////////////////////////////////////////
 
-		public (String, Serializee) HandleEarlyMethodRewrite( String name, Serializee declaringType, Serializee [] genericArguments )
+		public (String, SerializedTypeDescriptor) HandleEarlyMethodRewrite( String name, SerializedTypeDescriptor declaringType, SerializedTypeDescriptor [] genericArguments )
 		{
-			Dictionary< String, Serializee > ses = declaringType.AsMap();
-			String typeName = ses["n"].AsString();
+			String typeName = declaringType.typeName;
 
 // This is no longer done here, but stands as an example of how you could use this function.
 //			if( typeName == "<PrivateImplementationDetails>" && name == "ComputeStringHash" )
@@ -264,18 +263,16 @@ namespace Cilbox
 			return ( name, declaringType );
 		}
 
-		public bool OptionallyOverride( String name, Serializee declaringType, String fullSignature, bool isStatic, Serializee [] genericArguments, ref CilMetadataTokenInfo t )
+		public bool OptionallyOverride( String name, SerializedTypeDescriptor declaringType, String fullSignature, bool isStatic, SerializedTypeDescriptor [] genericArguments, ref CilMetadataTokenInfo t )
 		{
-			Dictionary< String, Serializee > ses = declaringType.AsMap();
-			String typeName = ses["n"].AsString();
+			String typeName = declaringType.typeName;
 
 			// We want to allow GetComponent and TryGetComponent.
 
 			if( (typeName == "UnityEngine.GameObject" || typeName == "UnityEngine.Component") && name == "GetComponent" && genericArguments.Length == 1 )
 			{
-				Type tTemplate = GetNativeTypeFromSerializee( genericArguments[0] );
-				Dictionary< String, Serializee > gatype = genericArguments[0].AsMap();
-				String genericTypeName = gatype["n"].AsString();
+				Type tTemplate = GetNativeTypeFromDescriptor( genericArguments[0] );
+				String genericTypeName = genericArguments[0].typeName;
 				int cilboxClassId = -1;
 				if( tTemplate != null || box.classes.TryGetValue( genericTypeName, out cilboxClassId ) )
 				{
@@ -299,9 +296,8 @@ namespace Cilbox
 			}
 			if( (typeName == "UnityEngine.GameObject" || typeName == "UnityEngine.Component") && name == "TryGetComponent" && genericArguments.Length == 1 )
 			{
-				Type tTemplate = GetNativeTypeFromSerializee( genericArguments[0] );
-				Dictionary< String, Serializee > gatype = genericArguments[0].AsMap();
-				String genericTypeName = gatype["n"].AsString();
+				Type tTemplate = GetNativeTypeFromDescriptor( genericArguments[0] );
+				String genericTypeName = genericArguments[0].typeName;
 				int cilboxClassId = -1;
 				if( tTemplate != null || box.classes.TryGetValue( genericTypeName, out cilboxClassId ) )
 				{
@@ -401,33 +397,29 @@ namespace Cilbox
 			return false;
 		}
 
-		public Type GetNativeTypeFromSerializee( Serializee s )
+		public Type GetNativeTypeFromDescriptor( SerializedTypeDescriptor td )
 		{
-			Dictionary< String, Serializee > ses = s.AsMap();
-			Serializee utSer;
-			if( ses.TryGetValue( "ut", out utSer ) ) return GetNativeTypeFromSerializee( utSer );
-			String typeName = ses["n"].AsString();
-			String assemblyName = ses["a"].AsString();
+			if( td.HasUnderlyingType ) return GetNativeTypeFromDescriptor( td.underlyingType );
+			String typeName = td.typeName;
+			String assemblyName = td.assemblyName;
 			if( IsCilboxInternalType( typeName ) ) return null;
 			if(box.GetTypeOverride( typeName, out Type overrideType )) {
-				Debug.Log( $"GetNativeTypeFromSerializee: Override {typeName} with {overrideType.FullName}" );
 				typeName = overrideType.FullName;
 				assemblyName = overrideType.Assembly.GetName().Name;
 			}
 			typeName = CheckReplaceTypeNotRecursive( typeName );
 			if( typeName == null ) return null;
 
-			Serializee g;
 			Type [] ga = null;
-			if( ses.TryGetValue( "g", out g ) )
+			if( td.IsGeneric )
 			{
-				// If there are generics (stored in g) then use the serialized generic name instead of stripped type name
-				// n = Namespace.Outer+Middle+Inner		gn = Namespace.Outer`1+Middle`2+Inner`1
-				typeName = ses["gn"].AsString();
-				Serializee [] gs = g.AsArray();
-				ga = new Type[gs.Length];
-				for( int i = 0; i < gs.Length; i++ ) {
-					Type gt = GetNativeTypeFromSerializee( gs[i] );
+				// If there are generics then use the serialized generic name instead of stripped type name
+				// typeName = Namespace.Outer+Middle+Inner		genericName = Namespace.Outer`1+Middle`2+Inner`1
+				typeName = td.genericName;
+				ga = new Type[td.genericArgs.Length];
+				for( int i = 0; i < td.genericArgs.Length; i++ )
+				{
+					Type gt = GetNativeTypeFromDescriptor( td.genericArgs[i] );
 					if( gt == null ) return null;
 					ga[i] = gt;
 				}
@@ -461,27 +453,22 @@ namespace Cilbox
 			return ret;
 		}
 
-		public String GetNativeTypeNameFromSerializee( Serializee s )
+		public String GetNativeTypeNameFromDescriptor( SerializedTypeDescriptor td )
 		{
-			Dictionary< String, Serializee > ses = s.AsMap();
-			Serializee utSer;
-			if( ses.TryGetValue( "ut", out utSer ) ) return GetNativeTypeNameFromSerializee( utSer );
-			String typeName = ses["n"].AsString();
+			if( td.HasUnderlyingType ) return GetNativeTypeNameFromDescriptor( td.underlyingType );
+			String typeName = td.typeName;
 			if( IsCilboxInternalType( typeName ) ) return typeName;
 			if(box.GetTypeOverride( typeName, out Type overrideType )) {
-				Debug.Log( $"GetNativeTypeFromSerializee: Override {typeName} with {overrideType.FullName}" );
 				typeName = overrideType.FullName;
 			}
 			typeName = CheckReplaceTypeNotRecursive( typeName );
 			if( typeName == null ) return null;
 
-			Serializee g;
-			if( ses.TryGetValue( "g", out g ) )
+			if( td.IsGeneric )
 			{
 				String ret = typeName + "`[";
-				Serializee [] gs = g.AsArray();
-				for( int i = 0; i < gs.Length; i++ )
-					ret += (i==0?"":",") + GetNativeTypeNameFromSerializee( gs[i] );
+				for( int i = 0; i < td.genericArgs.Length; i++ )
+					ret += (i==0?"":",") + GetNativeTypeNameFromDescriptor( td.genericArgs[i] );
 				return ret + "]";
 			}
 			else
@@ -490,11 +477,11 @@ namespace Cilbox
 			}
 		}
 
-		public Type [] TypeNamesToArrayOfNativeTypes( Serializee [] sa )
+		public Type [] DescriptorsToArrayOfNativeTypes( SerializedTypeDescriptor [] descs )
 		{
-			Type [] ret = new Type[sa.Length];
-			for( int i = 0; i < sa.Length; i++ )
-				ret[i] = GetNativeTypeFromSerializee( sa[i] );
+			Type [] ret = new Type[descs.Length];
+			for( int i = 0; i < descs.Length; i++ )
+				ret[i] = GetNativeTypeFromDescriptor( descs[i] );
 			return ret;
 		}
 

--- a/Packages/com.cnlohr.cilbox/CilboxUtil.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxUtil.cs
@@ -20,22 +20,24 @@ namespace Cilbox
 	//  STACK ELEMENT CONTAINER  //////////////////////////////////////////////
 	///////////////////////////////////////////////////////////////////////////
 
-	public enum StackType
+	// StackType is re-used for serialization of primitives, so don't change
+	// any of the enum values
+	public enum StackType : byte
 	{
-		Boolean,
-		Sbyte,
-		Byte,
-		Short,
-		Ushort,
-		Int,
-		Uint,
-		Long,
-		Ulong,
-		Float,
-		Double,
-		Object,
-		Address,
-		NativeHandle,
+		Boolean      = 0,
+		Sbyte        = 1,
+		Byte         = 2,
+		Short        = 3,
+		Ushort       = 4,
+		Int          = 5,
+		Uint         = 6,
+		Long         = 7,
+		Ulong        = 8,
+		Float        = 9,
+		Double       = 10,
+		Object       = 11,
+		Address      = 12,
+		NativeHandle = 13,
 	}
 
 	[StructLayout(LayoutKind.Explicit)]
@@ -758,32 +760,14 @@ namespace Cilbox
 				b.assemblyData = assemblyData;
 				b.BoxInitialize( true );
 
-				Dictionary< String, int > classes;
-				CilboxClass [] classesList;
+				SerializedAssembly asm = SerializedAssembly.Deserialize( assemblyData );
 
-				Dictionary< String, Serializee > assemblyRoot = new Serializee( Convert.FromBase64String( assemblyData ), Serializee.ElementType.Map ).AsMap();
-				Dictionary< String, Serializee > classData = assemblyRoot["classes"].AsMap();
-				Dictionary< String, Serializee > metaData = assemblyRoot["metadata"].AsMap();
-
-				int clsid = 0;
-				classes = new Dictionary< String, int >();
-				classesList = new CilboxClass[classData.Count];
-				foreach( var v in classData )
+				for( int ci = 0; ci < asm.classes.Length; ci++ )
 				{
-					CilboxClass cls = new CilboxClass();
-					classesList[clsid] = cls;
-					classes[(String)v.Key] = clsid;
-					clsid++;
-				}
+					SerializedClass sc = asm.classes[ci];
+					CilboxClass c = b.classesList[ci];
 
-				clsid = 0;
-				foreach( var v in classData )
-				{
-					CilboxClass c = classesList[clsid++];
-
-					c.LoadCilboxClass( b, v.Key, v.Value );
-
-					CLog.WriteLine( $"Class: {c.className}" );
+					CLog.WriteLine( $"Class: {sc.className}" );
 
 					String imports = "";
 					int numImportFunctions = Enum.GetNames(typeof(ImportFunctionID)).Length;
@@ -798,7 +782,7 @@ namespace Cilbox
 
 					CLog.WriteLine( "Static Fields:" );
 					for( int i = 0; i < c.staticFieldNames.Length; i++ )
-						CLog.WriteLine( $"\t{c.staticFieldTypes[i]} {c.staticFieldNames}[i]" );
+						CLog.WriteLine( $"\t{c.staticFieldTypes[i]} {c.staticFieldNames[i]}" );
 
 					CLog.WriteLine( "Instance Fields:" );
 					for( int i = 0; i < c.instanceFieldNames.Length; i++ )
@@ -822,7 +806,6 @@ namespace Cilbox
 						byte[] byteCode = m.byteCode;
 
 						int i = 0;
-						i = 0;
 						try {
 							do
 							{
@@ -924,38 +907,32 @@ namespace Cilbox
 					}
 				}
 
-				foreach( var v in metaData )
+				for( int mid = 0; mid < asm.metadata.Length; mid++ )
 				{
-					int mid = Convert.ToInt32((String)v.Key);
-					Dictionary< String, Serializee > st = v.Value.AsMap();
-					MetaTokenType metatype = (MetaTokenType)Convert.ToInt32(st["mt"].AsString());
-					//CilMetadataTokenInfo t = metadatas[mid] = new CilMetadataTokenInfo( metatype );
+					SerializedMetadataToken st = asm.metadata[mid];
+					MetaTokenType metatype = (MetaTokenType)st.metaTokenType;
 
-					//t.type = metatype;
-					//t.Name = "<UNKNOWN>";
-
-					String metaLine = $"\t{mid.ToString("X4")} {metatype.ToString().Substring(2),-7} ";
+					String metaLine = $"\t{(mid+1).ToString("X4")} {metatype.ToString().Substring(2),-7} ";
 
 					switch( metatype )
 					{
 					case MetaTokenType.mtString:
-						metaLine += st["s"].AsString();
+						metaLine += st.stringValue;
 						break;
 					case MetaTokenType.mtArrayInitializer:
-						metaLine += Convert.ToBase64String( st["data"].AsBlob() );
+						metaLine += Convert.ToBase64String( st.arrayInitData );
 						break;
 					case MetaTokenType.mtField:
-						Type t = b.usage.GetNativeTypeFromSerializee( st["dt"] );
-						if( Int32.Parse( st["isStatic"].AsString() ) > 0 ) metaLine += "static ";
+						Type t = b.usage.GetNativeTypeFromDescriptor( st.fieldDeclaringType );
+						if( st.fieldIsStatic ) metaLine += "static ";
 						String tname = t?.ToString();
 						if( t == null )
-							tname = "NR:" + st["dt"].AsMap()["n"].AsString() + " ";
-						metaLine += tname + st["name"].AsString();
+							tname = "NR:" + st.fieldDeclaringType.typeName + " ";
+						metaLine += tname + st.fieldName;
 						break;
 					case MetaTokenType.mtType:
 					{
-						Serializee typ = st["dt"];
-						Type nt = b.usage.GetNativeTypeFromSerializee( typ );
+						Type nt = b.usage.GetNativeTypeFromDescriptor( st.typeDescriptor );
 						StackType seType = StackElement.StackTypeFromType( nt );
 						if( seType < StackType.Object )
 						{
@@ -968,7 +945,7 @@ namespace Cilbox
 								bool bFound = false;
 								foreach( CilboxClass c in b.classesList )
 								{
-									if( c.className == typ.AsMap()["n"].AsString() )
+									if( c.className == st.typeDescriptor.typeName )
 									{
 										metaLine += $"PROXY: {c.className}";
 										bFound = true;
@@ -976,7 +953,7 @@ namespace Cilbox
 								}
 
 								if( !bFound )
-									throw new Exception( $"Type {typ.AsMap()["n"].AsString()} not available." );
+									throw new Exception( $"Type {st.typeDescriptor.typeName} not available." );
 							}
 							else
 							{
@@ -987,7 +964,7 @@ namespace Cilbox
 					}
 					case MetaTokenType.mtMethod:
 					{
-						metaLine += $"{st["name"].AsString()} {st["fullSignature"].AsString()} {st["assembly"].AsString()}";
+						metaLine += $"{st.methodName} {st.methodFullSignature} {st.methodAssembly}";
 						break;
 					}
 					}
@@ -1014,7 +991,7 @@ namespace Cilbox
 				UnityEngine.SceneManagement.Scene _scene = (UnityEngine.SceneManagement.Scene)scene;
 				if( !_scene.IsValid())
 				{
-					Debug.LogWarning($"Scene {_scene.name} is not valid. Returning empty MonoBehaviour array.");					
+					Debug.LogWarning($"Scene {_scene.name} is not valid. Returning empty MonoBehaviour array.");
 					return Array.Empty<MonoBehaviour>();
 				}
 
@@ -1078,55 +1055,6 @@ namespace Cilbox
 			}
 			return false;
 		}
-
-		// This does not check any rules, so it can be static.
-		public static Serializee GetSerializeeFromNativeType( Type t )
-		{
-			Dictionary< String, Serializee > ret = new Dictionary< String, Serializee >();
-			// Originally I did this to try to narrow down the search.  Now it is not as practical.
-			ret["a"] = new Serializee( t.Assembly.GetName().Name );
-			if( t.IsGenericType )
-			{
-				String genericDefName = t.GetGenericTypeDefinition().FullName;
-				StringBuilder typeNameBuilder = new StringBuilder();
-
-				// The following section strips out arity (`1, `2, etc) from the generic type definition name.
-				// This way we do not need to whitelist each generic arity of a type; We just need to whitelist the base name.
-				// Extreme example: Namespace.Outer`1+Middle`2+Inner`1 would be stripped to Namespace.Outer+Middle+Inner
-				for (int i = 0; i < genericDefName.Length; i++)
-				{
-					if (genericDefName[i] != '`')
-					{
-						typeNameBuilder.Append(genericDefName[i]);
-						continue;
-					}
-
-					int j = i + 1;
-					while (j < genericDefName.Length && char.IsDigit(genericDefName[j]))
-						j++;
-
-					if (j == genericDefName.Length || genericDefName[j] == '+' || genericDefName[j] == '[')
-						i = j - 1;
-				}
-				string baseName = typeNameBuilder.ToString();
-
-				ret["n"] = new Serializee( baseName );
-				ret["gn"] = new Serializee( genericDefName ); // Store the generic name so it does not have to be rebuilt
-				Type [] ta = t.GenericTypeArguments;
-				Serializee [] sg = new Serializee[ta.Length];
-				for( int i = 0; i < ta.Length; i++ )
-					sg[i] = GetSerializeeFromNativeType( ta[i] );
-				ret["g"] = new Serializee( sg );
-			}
-			else
-			{
-				ret["n"] = new Serializee( t.FullName );
-				if( t.IsEnum && HasCilboxableAttribute(t) )
-					ret["ut"] = GetSerializeeFromNativeType( t.GetEnumUnderlyingType() );
-			}
-			return new Serializee( ret );
-		}
-
 
 		///////////////////////////////////////////////////////////////////////////
 		//  DEFS FROM CECIL FOR PARSING CIL  //////////////////////////////////////

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -110,7 +110,7 @@ namespace TestCilbox
 			return whiteListField.Contains( sType + "." + sFieldName );
 		}
 
-		override public bool CheckMethodAllowed( out MethodInfo mi, Type declaringType, String name, Serializee [] parametersIn, Serializee [] genericArgumentsIn, String fullSignature )
+		override public bool CheckMethodAllowed( out MethodInfo mi, Type declaringType, String name, SerializedTypeDescriptor [] parametersIn, SerializedTypeDescriptor [] genericArgumentsIn, String fullSignature )
 		{
 			mi = null;
 
@@ -894,13 +894,12 @@ namespace TestCilbox
 			Cilbox.CilboxProxy proxy = new Cilbox.CilboxProxy();
 			proxy.fieldsObjects = new List<UnityEngine.Object>();
 
-			Dictionary<string, Serializee> dict = new Dictionary<string, Serializee>();
-			dict["t"] = new Serializee("obj");
-			dict["fo"] = new Serializee("-1");
-			Serializee serialized = new Serializee(dict);
+			Cilbox.SerializedProxyField spf = new Cilbox.SerializedProxyField();
+			spf.fieldType = (byte)Cilbox.ProxyFieldType.ObjectRef;
+			spf.fieldObjectIndex = -1;
 
 			MethodInfo method = typeof(Cilbox.CilboxProxy).GetMethod(
-				"LoadObjectFromSerializee",
+				"LoadObjectFromProxyField",
 				BindingFlags.Instance | BindingFlags.NonPublic);
 			if( method == null )
 			{
@@ -910,7 +909,7 @@ namespace TestCilbox
 
 			try
 			{
-				object[] args = new object[] { serialized, null, "badField", typeof(UnityEngine.Object), true, null };
+				object[] args = new object[] { spf, null, "badField", typeof(UnityEngine.Object) };
 				object result = method.Invoke(proxy, args);
 				bool loaded = result is bool b && b;
 				Validator.Set("Negative fieldsObjects index", loaded ? "loaded" : "ignored");

--- a/TestCilbox/TestCilbox.csproj
+++ b/TestCilbox/TestCilbox.csproj
@@ -13,6 +13,7 @@
 	<ItemGroup>
 		<Compile Include="../Packages/com.cnlohr.cilbox/Cilbox.cs" />
 		<Compile Include="../Packages/com.cnlohr.cilbox/CilboxProxy.cs" />
+        <Compile Include="../Packages/com.cnlohr.cilbox/CilboxSerialization.cs" />
 		<Compile Include="../Packages/com.cnlohr.cilbox/CilboxUtil.cs" />
 		<Compile Include="../Packages/com.cnlohr.cilbox/CilboxUsage.cs" />
 	</ItemGroup>


### PR DESCRIPTION
First part of the serialization overhaul: use typed structs for serialization/deserialization while conforming to the existing Serializee format.
I tested this with my test scene and it's bidirectionally compatible with the master branch. 
