### PR TITLE
Typed Struct Migration: Type Descriptors

### DIFF
--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -85,7 +85,8 @@ namespace Cilbox
 			{
 				Dictionary< String, Serializee > local = vl[i].AsMap();
 				methodLocals[iid] = local["name"].AsString();
-				typeLocals[iid] = parentClass.box.usage.GetNativeTypeFromSerializee( local["dt"] );
+				SerializedTypeDescriptor td = SerializedTypeDescriptor.FromSerializee( local["dt"] );
+				typeLocals[iid] = parentClass.box.usage.GetNativeTypeFromDescriptor( td );
 				iid++;
 			}
 
@@ -113,7 +114,8 @@ namespace Cilbox
 			{
 				Dictionary< String, Serializee > thisp = od[p].AsMap();
 				signatureParameters[sn] = thisp["name"].AsString();
-				typeParameters[sn] = parentClass.box.usage.GetNativeTypeFromSerializee( thisp["dt"] );
+				SerializedTypeDescriptor td  = SerializedTypeDescriptor.FromSerializee( thisp["dt"] );
+				typeParameters[sn] = parentClass.box.usage.GetNativeTypeFromDescriptor(td);
 				sn++;
 			}
 
@@ -133,9 +135,10 @@ namespace Cilbox
 					clause.HandlerOffset = Convert.ToInt32(thisehc["hOff"].AsString());
 					clause.HandlerLength = Convert.ToInt32(thisehc["hLen"].AsString());
 					clause.HandlerEndOffset = clause.HandlerOffset + clause.HandlerLength;
-					if (thisehc.ContainsKey("cType"))
+					if (thisehc.TryGetValue("cType", out Serializee cTypeSer))
 					{
-						clause.CatchType = parentClass.box.usage.GetNativeTypeFromSerializee(thisehc["cType"]);
+						SerializedTypeDescriptor td = SerializedTypeDescriptor.FromSerializee(cTypeSer);
+						clause.CatchType = parentClass.box.usage.GetNativeTypeFromDescriptor(td);
 						if (clause.CatchType == null)
 						{
 							// Check if it's a Cilboxable type
@@ -2078,7 +2081,8 @@ spiperf.End();
 			{
 				Dictionary< String, Serializee > field = staticFields[k].AsMap();
 				String fieldName = staticFieldNames[id] = field["name"].AsString();
-				Type t = staticFieldTypes[id] = box.usage.GetNativeTypeFromSerializee( field["type"] );
+				SerializedTypeDescriptor td = SerializedTypeDescriptor.FromSerializee(field["type"]);
+				Type t = staticFieldTypes[id] = box.usage.GetNativeTypeFromDescriptor( td );
 
 				//staticFieldIDs[id] = Cilbox.FindInternalMetadataID( className, 4, fieldName );
 				this.staticFields[id] = CilboxUtil.DeserializeDataForProxyField( t, "" );
@@ -2095,7 +2099,8 @@ spiperf.End();
 			{
 				Dictionary< String, Serializee > field = instanceFields[k].AsMap();
 				String fieldName = instanceFieldNames[id] = field["name"].AsString();
-				instanceFieldTypes[id] = box.usage.GetNativeTypeFromSerializee( field["type"] );
+				SerializedTypeDescriptor td = SerializedTypeDescriptor.FromSerializee(field["type"]);
+				instanceFieldTypes[id] = box.usage.GetNativeTypeFromDescriptor( td );
 				id++;
 			}
 
@@ -2266,7 +2271,7 @@ spiperf.End();
 			usage = new CilboxUsage( this );
 		}
 
-		abstract public bool CheckMethodAllowed( out MethodInfo mi, Type declaringType, String name, Serializee [] parametersIn, Serializee [] genericArgumentsIn, String fullSignature );
+		abstract public bool CheckMethodAllowed( out MethodInfo mi, Type declaringType, String name, SerializedTypeDescriptor [] parametersIn, SerializedTypeDescriptor [] genericArgumentsIn, String fullSignature );
 		abstract public bool CheckTypeAllowed( String sType );
 		abstract public bool CheckFieldAllowed( String sType, String sFieldName );
 		abstract public bool GetTypeOverride( String sType, out Type t );
@@ -2320,7 +2325,8 @@ spiperf.End();
 					var enumProps = kv.Value.AsMap();
 					CilboxEnum ce = new CilboxEnum();
 					ce.enumName = kv.Key;
-					ce.underlyingType = StackElement.StackTypeFromType(usage.GetNativeTypeFromSerializee(enumProps["ut"]));
+					SerializedTypeDescriptor td = SerializedTypeDescriptor.FromSerializee(enumProps["ut"]);
+					ce.underlyingType = StackElement.StackTypeFromType(usage.GetNativeTypeFromDescriptor(td));
 					ce.valueToName = new Dictionary<long, string>();
 					foreach (var entry in enumProps["values"].AsArray())
 					{
@@ -2356,8 +2362,9 @@ spiperf.End();
 				case MetaTokenType.mtField:
 					// The type has been "sealed" so-to-speak. In that we have an index for it.
 
+					SerializedTypeDescriptor td = SerializedTypeDescriptor.FromSerializee(st["dt"]);
 					t.Name = st["name"].AsString();
-					t.declaringTypeName = usage.GetNativeTypeNameFromSerializee( st["dt"] );
+					t.declaringTypeName = usage.GetNativeTypeNameFromDescriptor( td );
 					t.fieldIsStatic = Convert.ToInt32(st["isStatic"].AsString()) != 0;
 
 					if( st.ContainsKey("index") )
@@ -2375,8 +2382,7 @@ spiperf.End();
 						}
 						t.isFieldWhiteListed = true;
 
-						Serializee typ = st["dt"];
-						Type ty = usage.GetNativeTypeFromSerializee( typ );
+						Type ty = usage.GetNativeTypeFromDescriptor( td );
 						if( ty == null )
 						{
 							throw new CilboxException( $"Could not get allowed type for checking field, {t.declaringTypeName} in {v.Key}." );
@@ -2423,8 +2429,8 @@ spiperf.End();
 					break;
 				case MetaTokenType.mtType:
 				{
-					Serializee typ = st["dt"];
-					t.nativeType = usage.GetNativeTypeFromSerializee( typ );
+					SerializedTypeDescriptor td2 = SerializedTypeDescriptor.FromSerializee(st["dt"]);
+					t.nativeType = usage.GetNativeTypeFromDescriptor( td2 );
 					StackType seType = StackElement.StackTypeFromType( t.nativeType );
 					if( seType < StackType.Object )
 					{
@@ -2433,7 +2439,7 @@ spiperf.End();
 						t.Name = t.nativeType.ToString();
 
 						// Link to CilboxEnum if this was a cilboxable enum serialized by underlying type.
-						string origName = typ.AsMap()["n"].AsString();
+						string origName = td2.typeName;
 						if (cilboxEnums != null && cilboxEnums.TryGetValue(origName, out CilboxEnum cilboxEnumDef))
 						{
 							t.cilboxEnum = cilboxEnumDef;
@@ -2443,17 +2449,15 @@ spiperf.End();
 					else if( t.nativeType != null )
 					{
 						t.isValid = true;
-						t.Name = "Type: " + typ.AsMap()["n"].AsString();
+						t.Name = "Type: " + td2.typeName;
 					}
 					else
 					{
-						Dictionary< String, Serializee > typMap = typ.AsMap();
-
 						// Maybe it's a type inside our cilbox?
 						t.isValid = false;
 						foreach( CilboxClass c in classesList )
 						{
-							if( c.className == typMap["n"].AsString() )
+							if( c.className == td2.typeName )
 							{
 								t.Name = c.className;
 								t.nativeTypeIsCilboxProxy = true;
@@ -2462,7 +2466,7 @@ spiperf.End();
 						}
 
 						if( !t.isValid )
-							Debug.LogError( $"Error: Could not find type: {typMap["n"].AsString()}" );
+							Debug.LogError( $"Error: Could not find type: {td2.typeName}" );
 					}
 					break;
 				}
@@ -2472,32 +2476,33 @@ spiperf.End();
 					String fullSignature = st["fullSignature"].AsString();
 					bool isStatic = Convert.ToInt32( st["isStatic"].AsString() ) != 0;
 					String useAssembly = st["assembly"].AsString();
-					Serializee [] genericArguments = null;
+					SerializedTypeDescriptor [] genericArguments = null;
 					t.Name = "Method: " + name;
 
 					//Possibly get genericArguments
 					Serializee temp;
 					if( st.TryGetValue( "ga", out temp ) )
-						genericArguments = temp.AsArray();
+						genericArguments = SerializedTypeDescriptor.FromSerializeeArray(temp);
 					else
-						genericArguments = new Serializee[0];
+						genericArguments = new SerializedTypeDescriptor[0];
 
-					if( usage.OptionallyOverride( name, st["dt"], fullSignature, isStatic, genericArguments, ref t ) )
+					SerializedTypeDescriptor dt = SerializedTypeDescriptor.FromSerializee( st["dt"] );
+					if( usage.OptionallyOverride( name, dt, fullSignature, isStatic, genericArguments, ref t ) )
 					{
 						break;
 					}
 
-					Serializee stDt;
-					(name, stDt) = usage.HandleEarlyMethodRewrite( name, st["dt"], genericArguments );
+					SerializedTypeDescriptor stDt;
+					(name, stDt) = usage.HandleEarlyMethodRewrite( name, dt, genericArguments );
 
-					string declaringTypeName = t.declaringTypeName = usage.GetNativeTypeNameFromSerializee( stDt );
+					string declaringTypeName = t.declaringTypeName = usage.GetNativeTypeNameFromDescriptor( stDt );
 
 
-					Serializee [] parametersSer = null;
+					SerializedTypeDescriptor [] parametersSer = null;
 					if( st.TryGetValue( "parameters", out temp ) )
-						parametersSer = temp.AsArray();
+						parametersSer = SerializedTypeDescriptor.FromSerializeeArray(temp);
 					else
-						parametersSer = new Serializee[0];
+						parametersSer = new SerializedTypeDescriptor[0];
 
 					// First, see if this is to a class we are responsible for. Like does it come from _this_ class?
 					int classid;
@@ -2525,7 +2530,7 @@ spiperf.End();
 					}
 					else
 					{
-						Type declaringType = usage.GetNativeTypeFromSerializee( stDt );
+						Type declaringType = usage.GetNativeTypeFromDescriptor( stDt );
 						if( declaringType == null )
 							throw new CilboxException( $"Error: Could not find referenced type {useAssembly}/{declaringTypeName}/" );
 
@@ -2961,7 +2966,7 @@ spiperf.End();
 													{
 														Serializee [] argtypes = new Serializee[templateArguments.Length];
 														for( int a = 0; a < templateArguments.Length; a++ )
-															argtypes[a] = CilboxUtil.GetSerializeeFromNativeType( templateArguments[a] );
+															argtypes[a] = SerializedTypeDescriptorBuilder.FromNativeType( templateArguments[a] ).ToSerializee();
 														methodProps["ga"] = new Serializee( argtypes );
 													}
 												}
@@ -2974,7 +2979,7 @@ spiperf.End();
 													TypesInUseInSceneList.Add( tmb.DeclaringType );
 												}
 
-												methodProps["dt"] = CilboxUtil.GetSerializeeFromNativeType( tmb.DeclaringType );
+												methodProps["dt"] = SerializedTypeDescriptorBuilder.FromNativeType( tmb.DeclaringType ).ToSerializee();
 												methodProps["name"] = new Serializee( tmb.Name );
 
 												System.Reflection.ParameterInfo[] parameterInfos = tmb.GetParameters();
@@ -2983,8 +2988,7 @@ spiperf.End();
 													Serializee [] parametersSer = new Serializee[parameterInfos.Length];
 													for( var j = 0; j < parameterInfos.Length; j++ )
 													{
-														Type ty = parameterInfos[j].ParameterType;
-														parametersSer[j] = CilboxUtil.GetSerializeeFromNativeType( ty );
+														parametersSer[j] = SerializedTypeDescriptorBuilder.FromNativeType( parameterInfos[j].ParameterType ).ToSerializee();
 													}
 													methodProps["parameters"] = new Serializee( parametersSer );
 												}
@@ -3015,7 +3019,7 @@ spiperf.End();
 
 												Dictionary<String, Serializee> fieldProps = new Dictionary<String, Serializee>();
 												fieldProps["mt"] = new Serializee( ((int)MetaTokenType.mtField).ToString() );
-												fieldProps["dt"] = CilboxUtil.GetSerializeeFromNativeType( rf.DeclaringType );
+												fieldProps["dt"] = SerializedTypeDescriptorBuilder.FromNativeType( rf.DeclaringType ).ToSerializee();
 												fieldProps["name"] = new Serializee( rf.Name );
 												//fieldProps["fullName"] = rf.FieldType.FullName;
 												fieldProps["isStatic"] = new Serializee( (rf.IsStatic?1:0).ToString() );
@@ -3031,7 +3035,7 @@ spiperf.End();
 												Type ty = proxyAssembly.ManifestModule.ResolveType( (int)operand );
 												Dictionary<String, Serializee> fieldProps = new Dictionary<String, Serializee>();
 												fieldProps["mt"] = new Serializee( ((int)MetaTokenType.mtType).ToString() );
-												fieldProps["dt"] = CilboxUtil.GetSerializeeFromNativeType( ty );
+												fieldProps["dt"] = SerializedTypeDescriptorBuilder.FromNativeType( ty ).ToSerializee();
 												assemblyMetadata[(mdcount++).ToString()] = new Serializee( fieldProps );
 												originalMetaToFriendlyName[writebackToken] = ty.FullName;
 											}
@@ -3074,7 +3078,7 @@ spiperf.End();
 
 									if( c.Flags == ExceptionHandlingClauseOptions.Clause && c.CatchType != null )
 									{
-										exc["cType"] = CilboxUtil.GetSerializeeFromNativeType( c.CatchType );
+										exc["cType"] = SerializedTypeDescriptorBuilder.FromNativeType( c.CatchType ).ToSerializee();
 									}
 									excArray[k] = new Serializee( exc );
 								}
@@ -3087,7 +3091,7 @@ spiperf.End();
 								LocalVariableInfo lvi = mb.LocalVariables[i];
 								Dictionary< String, Serializee > local = new Dictionary< String, Serializee >();
 								local["name"] = new Serializee( lvi.ToString() );
-								local["dt"] = CilboxUtil.GetSerializeeFromNativeType( lvi.LocalType );
+								local["dt"] = SerializedTypeDescriptorBuilder.FromNativeType( lvi.LocalType ).ToSerializee();
 								localVars[i] = new Serializee( local );
 							}
 							MethodProps["locals"] = new Serializee( localVars );
@@ -3099,7 +3103,7 @@ spiperf.End();
 							{
 								Dictionary< String, Serializee > tpi = new Dictionary< String, Serializee >();
 								tpi["name"] = new Serializee( parameters[i].Name );
-								tpi["dt"] = CilboxUtil.GetSerializeeFromNativeType( parameters[i].ParameterType );
+								tpi["dt"] = SerializedTypeDescriptorBuilder.FromNativeType(parameters[i].ParameterType ).ToSerializee();
 								parameterList[i] = new Serializee( tpi );
 							}
 							MethodProps["parameters"] = new Serializee( parameterList );
@@ -3157,7 +3161,7 @@ spiperf.End();
 						{
 							Dictionary< String, Serializee > dictField = new Dictionary< String, Serializee >();
 							dictField["name"] = new Serializee( f.Name );
-							dictField["type"] = CilboxUtil.GetSerializeeFromNativeType( f.FieldType );
+							dictField["type"] = SerializedTypeDescriptorBuilder.FromNativeType( f.FieldType ).ToSerializee();
 							fields.Add( new Serializee( dictField ) );
 
 							// Fill in our metadata with a class-specific field ID, if this field ID was used in code anywhere.
@@ -3198,7 +3202,7 @@ spiperf.End();
 					if (!type.IsEnum || !CilboxUtil.HasCilboxableAttribute(type))
 						continue;
 					Dictionary< String, Serializee > enumProps = new Dictionary< String, Serializee >();
-					enumProps["ut"] = CilboxUtil.GetSerializeeFromNativeType(type.GetEnumUnderlyingType());
+					enumProps["ut"] = SerializedTypeDescriptorBuilder.FromNativeType(type.GetEnumUnderlyingType()).ToSerializee();
 					string[] names = Enum.GetNames(type);
 					Array values = Enum.GetValues(type);
 					Serializee[] entries = new Serializee[names.Length];

--- a/Packages/com.cnlohr.cilbox/CilboxProxy.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxProxy.cs
@@ -111,7 +111,8 @@ namespace Cilbox
 				return new Serializee(instanceFields);
 			}
 
-			bool hasCilboxable = CilboxUtil.HasCilboxableAttribute( fv.GetType() );
+			Type fvType = fv.GetType();
+			bool hasCilboxable = CilboxUtil.HasCilboxableAttribute( fvType );
 
 
 			if( fName != null )
@@ -127,10 +128,10 @@ namespace Cilbox
 			StackType st;
 
 			// Serialize enum field as underlying type
-			if( fv.GetType().IsEnum )
+			if( fvType.IsEnum )
 			{
-				object underlying = Convert.ChangeType( fv, fv.GetType().GetEnumUnderlyingType() );
-				if( StackElement.TypeToStackType.TryGetValue( underlying.GetType().ToString(), out st ) && st < StackType.Object )
+				object underlying = Convert.ChangeType( fv, fvType.GetEnumUnderlyingType() );
+				if( StackElement.TypeToStackType.TryGetValue( fvType.ToString(), out st ) && st < StackType.Object )
 				{
 					instanceFields["d"] = new Serializee(underlying.ToString());
 					instanceFields["t"] = new Serializee("e" + st);
@@ -157,16 +158,15 @@ namespace Cilbox
 				instanceFields["d"] = new Serializee(fv.ToString());
 				instanceFields["t"] = new Serializee("s");
 			}
-			else if( StackElement.TypeToStackType.TryGetValue( fv.GetType().ToString(), out st ) && st < StackType.Object )
+			else if( StackElement.TypeToStackType.TryGetValue( fvType.ToString(), out st ) && st < StackType.Object )
 			{
 				instanceFields["d"] = new Serializee(fv.ToString());
 				instanceFields["t"] = new Serializee("e" + st);
 			}
-			else if( fv.GetType().IsArray )
+			else if( fvType.IsArray )
 			{
 				instanceFields["t"] = new Serializee( "a" );
-				Type type = fv.GetType().GetElementType();
-				instanceFields["at"] = CilboxUtil.GetSerializeeFromNativeType( type );
+				instanceFields["at"] = SerializedTypeDescriptorBuilder.FromNativeType(fvType.GetElementType()).ToSerializee();
 				Array arr = (Array)fv;
 				int len = arr.Length;
 				instanceFields["al"] = new Serializee( len.ToString() );
@@ -185,8 +185,7 @@ namespace Cilbox
 				string json = JsonUtility.ToJson(fv);
 				instanceFields["t"] = new Serializee( "j" );
 				instanceFields["d"] = new Serializee(json);
-				Type type = fv.GetType();
-				instanceFields["at"] = CilboxUtil.GetSerializeeFromNativeType( type );
+				instanceFields["at"] = SerializedTypeDescriptorBuilder.FromNativeType(fvType).ToSerializee();
 			}
 
 
@@ -433,7 +432,8 @@ namespace Cilbox
 						dict.TryGetValue( "ad", out seAD ) &&
 						Int32.TryParse( seAL.AsString(), out aLen ) )
 					{
-						Type t = box.usage.GetNativeTypeFromSerializee( seAT );
+						SerializedTypeDescriptor tdAT = SerializedTypeDescriptor.FromSerializee( seAT );
+						Type t = box.usage.GetNativeTypeFromDescriptor(tdAT);
 						bool isCilboxElementType = false;
 
 						if (t == null)
@@ -492,7 +492,8 @@ namespace Cilbox
 						dict.TryGetValue( "at", out seAT ) &&
 						dict.TryGetValue( "d", out seD ) )
 					{
-						Type t = box.usage.GetNativeTypeFromSerializee( seAT ); // This makes sure we're allowed to have this type.
+						SerializedTypeDescriptor tdAT = SerializedTypeDescriptor.FromSerializee( seAT );
+						Type t = box.usage.GetNativeTypeFromDescriptor(tdAT); // This makes sure we're allowed to have this type.
 						oOut = JsonUtility.FromJson(seD.AsString(), t);
 						return true;
 					}

--- a/Packages/com.cnlohr.cilbox/CilboxSerialization.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxSerialization.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Cilbox
+{
+	public class SerializedTypeDescriptor
+	{
+		public string assemblyName;
+		public string typeName;
+		// Generic fields (present when genericArgs token written)
+		public string genericName;
+		public SerializedTypeDescriptor[] genericArgs;
+		// Underlying type (present when underlyingType token written)
+		public SerializedTypeDescriptor underlyingType;
+
+		public bool IsGeneric => genericArgs != null && genericArgs.Length > 0;
+		public bool HasUnderlyingType => underlyingType != null;
+
+		// Mirrors CilboxUtil.GetSerializeeFromNativeType key order: a, then
+		// (n, gn, g) for generics or (n, [ut]) otherwise.
+		public Serializee ToSerializee()
+		{
+			Dictionary<String, Serializee> ret = new Dictionary<String, Serializee>();
+			ret["a"] = new Serializee( assemblyName );
+			if( IsGeneric )
+			{
+				ret["n"] = new Serializee( typeName );
+				ret["gn"] = new Serializee( genericName );
+				Serializee[] sg = new Serializee[genericArgs.Length];
+				for( int i = 0; i < genericArgs.Length; i++ )
+					sg[i] = genericArgs[i].ToSerializee();
+				ret["g"] = new Serializee( sg );
+			}
+			else
+			{
+				ret["n"] = new Serializee( typeName );
+				if( underlyingType != null )
+					ret["ut"] = underlyingType.ToSerializee();
+			}
+			return new Serializee( ret );
+		}
+
+		public static SerializedTypeDescriptor FromSerializee( Serializee s )
+		{
+			Dictionary<String, Serializee> m = s.AsMap();
+			SerializedTypeDescriptor td = new SerializedTypeDescriptor();
+			td.assemblyName = m["a"].AsString();
+			td.typeName = m["n"].AsString();
+			if( m.TryGetValue( "g", out Serializee g ) )
+			{
+				td.genericName = m["gn"].AsString();
+				Serializee[] ga = g.AsArray();
+				td.genericArgs = new SerializedTypeDescriptor[ga.Length];
+				for( int i = 0; i < ga.Length; i++ )
+					td.genericArgs[i] = FromSerializee( ga[i] );
+			}
+			if( m.TryGetValue( "ut", out Serializee ut ) )
+				td.underlyingType = FromSerializee( ut );
+			return td;
+		}
+
+		public static SerializedTypeDescriptor[] FromSerializeeArray(Serializee s)
+		{
+			Serializee[] sArr = s.AsArray();
+			SerializedTypeDescriptor[] tdArr = new SerializedTypeDescriptor[sArr.Length];
+			for (int i = 0; i < sArr.Length; i++)
+			{
+				tdArr[i] = FromSerializee(sArr[i]);
+			}
+			return tdArr;
+		}
+	}
+
+	/// <summary>
+	/// Helper to build a SerializedTypeDescriptor from a native System.Type.
+	/// Used by the editor compiler to build type descriptors from native System.Type.
+	/// </summary>
+	public static class SerializedTypeDescriptorBuilder
+	{
+		public static SerializedTypeDescriptor FromNativeType(Type t)
+		{
+			var td = new SerializedTypeDescriptor();
+			td.assemblyName = t.Assembly.GetName().Name;
+
+			if (t.IsGenericType)
+			{
+				string genericDefName = t.GetGenericTypeDefinition().FullName;
+				// Strip arity markers (`1, `2) from the generic definition name
+				var sb = new StringBuilder();
+				for (int i = 0; i < genericDefName.Length; i++)
+				{
+					if (genericDefName[i] != '`')
+					{
+						sb.Append(genericDefName[i]);
+						continue;
+					}
+
+					int j = i + 1;
+					while (j < genericDefName.Length && char.IsDigit(genericDefName[j]))
+						j++;
+					if (j == genericDefName.Length || genericDefName[j] == '+' || genericDefName[j] == '[')
+						i = j - 1;
+				}
+				td.typeName = sb.ToString();
+				td.genericName = genericDefName;
+				Type[] ta = t.GenericTypeArguments;
+				td.genericArgs = new SerializedTypeDescriptor[ta.Length];
+				for (int i = 0; i < ta.Length; i++)
+					td.genericArgs[i] = FromNativeType(ta[i]);
+			}
+			else
+			{
+				td.typeName = t.FullName;
+				if (t.IsEnum && CilboxUtil.HasCilboxableAttribute(t))
+					td.underlyingType = FromNativeType(t.GetEnumUnderlyingType());
+			}
+			return td;
+		}
+	}
+}

--- a/Packages/com.cnlohr.cilbox/CilboxSerialization.cs.meta
+++ b/Packages/com.cnlohr.cilbox/CilboxSerialization.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a2cce3ccd1c12bf4ebb6f5de53bd0000

--- a/Packages/com.cnlohr.cilbox/CilboxUsage.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxUsage.cs
@@ -6,7 +6,7 @@
 // Security Checking:
 //   For Methods:
 //     1. HandleEarlyMethodRewrite() -- This can rewrite declaring type + method.
-//     2. GetNativeTypeNameFromSerializee on declaring type
+//     2. GetNativeTypeNameFromDescriptor on declaring type
 //     3. GetNativeMethodFromTypeAndName - Sometimes swap-out stuff
 //        a. If rewritten, overrides all further security and fast-paths.
 //     4. InternalGetNativeMethodFromTypeAndNameNoSecurity
@@ -17,14 +17,14 @@
 //     8. If disallowed, abort.  If allowed, and overridden, bypass any further checks.
 //
 //
-//   GetNativeTypeFromSerializee (can only be used on non-templated types)
+//   GetNativeTypeFromDescriptor (can only be used on non-templated types)
 //     1. Checks to see if it's a type from within this cilbox.  If so GO!
 //     2. CheckReplaceTypeNotRecursive ON BASE TYPE ONLY
-//     3. Recursively check all template types through GetNativeTypeFromSerializee
+//     3. Recursively check all template types through GetNativeTypeFromDescriptor
 //     4. Type.GetType
 //     5. MakeGenericType
 //
-//   GetNativeTypeNameFromSerializee mimics GetNativeTypeFromSerializee
+//   GetNativeTypeNameFromDescriptor mimics GetNativeTypeFromDescriptor
 //
 //   CheckTypeSecurity calls CheckTypeAllowed on the specific cilbox.
 //    If it is allowed, continue normal checks.  If it is disallowed, abort.
@@ -60,7 +60,7 @@ namespace Cilbox
 			return false;
 		}
 
-		public MethodBase GetNativeMethodFromTypeAndName( Type declaringType, String name, Serializee [] parametersIn, Serializee [] genericArgumentsIn, String fullSignature )
+		public MethodBase GetNativeMethodFromTypeAndName( Type declaringType, String name, SerializedTypeDescriptor [] parametersIn, SerializedTypeDescriptor [] genericArgumentsIn, String fullSignature )
 		{
 			MethodInfo mi = null;
 			if(!box.CheckMethodAllowed( out mi, declaringType, name, parametersIn, genericArgumentsIn, fullSignature ))
@@ -80,8 +80,8 @@ namespace Cilbox
 				return mi;
 			}
 
-			Type[] parameters = TypeNamesToArrayOfNativeTypes( parametersIn );
-			Type[] genericArguments = TypeNamesToArrayOfNativeTypes( genericArgumentsIn );
+			Type[] parameters = DescriptorsToArrayOfNativeTypes( parametersIn );
+			Type[] genericArguments = DescriptorsToArrayOfNativeTypes( genericArgumentsIn );
 
 			MethodBase m = InternalGetNativeMethodFromTypeAndNameNoSecurity( declaringType, name, parameters, genericArguments, fullSignature );
 
@@ -90,7 +90,7 @@ namespace Cilbox
 			{
 				if( !CheckTypeSecurityRecursive(parameters[i]) )
 				{
-                    string typeName = genericArgumentsIn[i].AsMap()["n"].AsString();
+					string typeName = parametersIn[i].typeName;
 					Debug.LogError( $"Privilege failed for {declaringType}.{name} parameter {i} type {typeName}" );
 					return null;
 				}
@@ -99,7 +99,7 @@ namespace Cilbox
 			{
 				if( !CheckTypeSecurityRecursive(genericArguments[i]) )
 				{
-                    string typeName = genericArgumentsIn[i].AsMap()["n"].AsString();
+					string typeName = genericArgumentsIn[i].typeName;
 					Debug.LogError( $"Privilege failed for {declaringType}.{name} generic argument {i} type {typeName}" );
 					return null;
 				}
@@ -247,10 +247,9 @@ namespace Cilbox
 		// REWRITERS ///////////////////////////////////////////////////////////////////////
 		////////////////////////////////////////////////////////////////////////////////////
 
-		public (String, Serializee) HandleEarlyMethodRewrite( String name, Serializee declaringType, Serializee [] genericArguments )
+		public (String, SerializedTypeDescriptor) HandleEarlyMethodRewrite( String name, SerializedTypeDescriptor declaringType, SerializedTypeDescriptor [] genericArguments )
 		{
-			Dictionary< String, Serializee > ses = declaringType.AsMap();
-			String typeName = ses["n"].AsString();
+			String typeName = declaringType.typeName;
 
 // This is no longer done here, but stands as an example of how you could use this function.
 //			if( typeName == "<PrivateImplementationDetails>" && name == "ComputeStringHash" )
@@ -264,18 +263,16 @@ namespace Cilbox
 			return ( name, declaringType );
 		}
 
-		public bool OptionallyOverride( String name, Serializee declaringType, String fullSignature, bool isStatic, Serializee [] genericArguments, ref CilMetadataTokenInfo t )
+		public bool OptionallyOverride( String name, SerializedTypeDescriptor declaringType, String fullSignature, bool isStatic, SerializedTypeDescriptor [] genericArguments, ref CilMetadataTokenInfo t )
 		{
-			Dictionary< String, Serializee > ses = declaringType.AsMap();
-			String typeName = ses["n"].AsString();
+			String typeName = declaringType.typeName;
 
 			// We want to allow GetComponent and TryGetComponent.
 
 			if( (typeName == "UnityEngine.GameObject" || typeName == "UnityEngine.Component") && name == "GetComponent" && genericArguments.Length == 1 )
 			{
-				Type tTemplate = GetNativeTypeFromSerializee( genericArguments[0] );
-				Dictionary< String, Serializee > gatype = genericArguments[0].AsMap();
-				String genericTypeName = gatype["n"].AsString();
+				Type tTemplate = GetNativeTypeFromDescriptor( genericArguments[0] );
+				String genericTypeName = genericArguments[0].typeName;
 				int cilboxClassId = -1;
 				if( tTemplate != null || box.classes.TryGetValue( genericTypeName, out cilboxClassId ) )
 				{
@@ -299,9 +296,8 @@ namespace Cilbox
 			}
 			if( (typeName == "UnityEngine.GameObject" || typeName == "UnityEngine.Component") && name == "TryGetComponent" && genericArguments.Length == 1 )
 			{
-				Type tTemplate = GetNativeTypeFromSerializee( genericArguments[0] );
-				Dictionary< String, Serializee > gatype = genericArguments[0].AsMap();
-				String genericTypeName = gatype["n"].AsString();
+				Type tTemplate = GetNativeTypeFromDescriptor( genericArguments[0] );
+				String genericTypeName = genericArguments[0].typeName;
 				int cilboxClassId = -1;
 				if( tTemplate != null || box.classes.TryGetValue( genericTypeName, out cilboxClassId ) )
 				{
@@ -401,33 +397,30 @@ namespace Cilbox
 			return false;
 		}
 
-		public Type GetNativeTypeFromSerializee( Serializee s )
+		public Type GetNativeTypeFromDescriptor( SerializedTypeDescriptor td )
 		{
-			Dictionary< String, Serializee > ses = s.AsMap();
-			Serializee utSer;
-			if( ses.TryGetValue( "ut", out utSer ) ) return GetNativeTypeFromSerializee( utSer );
-			String typeName = ses["n"].AsString();
-			String assemblyName = ses["a"].AsString();
+			if( td.HasUnderlyingType ) return GetNativeTypeFromDescriptor( td.underlyingType );
+			String typeName = td.typeName;
+			String assemblyName = td.assemblyName;
 			if( IsCilboxInternalType( typeName ) ) return null;
 			if(box.GetTypeOverride( typeName, out Type overrideType )) {
-				Debug.Log( $"GetNativeTypeFromSerializee: Override {typeName} with {overrideType.FullName}" );
+				Debug.Log( $"{nameof(GetNativeTypeFromDescriptor)}: Override {typeName} with {overrideType.FullName}" );
 				typeName = overrideType.FullName;
 				assemblyName = overrideType.Assembly.GetName().Name;
 			}
 			typeName = CheckReplaceTypeNotRecursive( typeName );
 			if( typeName == null ) return null;
 
-			Serializee g;
 			Type [] ga = null;
-			if( ses.TryGetValue( "g", out g ) )
+			if( td.IsGeneric )
 			{
-				// If there are generics (stored in g) then use the serialized generic name instead of stripped type name
-				// n = Namespace.Outer+Middle+Inner		gn = Namespace.Outer`1+Middle`2+Inner`1
-				typeName = ses["gn"].AsString();
-				Serializee [] gs = g.AsArray();
-				ga = new Type[gs.Length];
-				for( int i = 0; i < gs.Length; i++ ) {
-					Type gt = GetNativeTypeFromSerializee( gs[i] );
+				// If there are generics then use the serialized generic name instead of stripped type name
+				// typeName = Namespace.Outer+Middle+Inner		genericName = Namespace.Outer`1+Middle`2+Inner`1
+				typeName = td.genericName;
+				ga = new Type[td.genericArgs.Length];
+				for( int i = 0; i < td.genericArgs.Length; i++ )
+				{
+					Type gt = GetNativeTypeFromDescriptor( td.genericArgs[i] );
 					if( gt == null ) return null;
 					ga[i] = gt;
 				}
@@ -461,27 +454,22 @@ namespace Cilbox
 			return ret;
 		}
 
-		public String GetNativeTypeNameFromSerializee( Serializee s )
+		public String GetNativeTypeNameFromDescriptor( SerializedTypeDescriptor td )
 		{
-			Dictionary< String, Serializee > ses = s.AsMap();
-			Serializee utSer;
-			if( ses.TryGetValue( "ut", out utSer ) ) return GetNativeTypeNameFromSerializee( utSer );
-			String typeName = ses["n"].AsString();
+			if( td.HasUnderlyingType ) return GetNativeTypeNameFromDescriptor( td.underlyingType );
+			String typeName = td.typeName;
 			if( IsCilboxInternalType( typeName ) ) return typeName;
 			if(box.GetTypeOverride( typeName, out Type overrideType )) {
-				Debug.Log( $"GetNativeTypeFromSerializee: Override {typeName} with {overrideType.FullName}" );
 				typeName = overrideType.FullName;
 			}
 			typeName = CheckReplaceTypeNotRecursive( typeName );
 			if( typeName == null ) return null;
 
-			Serializee g;
-			if( ses.TryGetValue( "g", out g ) )
+			if( td.IsGeneric )
 			{
 				String ret = typeName + "`[";
-				Serializee [] gs = g.AsArray();
-				for( int i = 0; i < gs.Length; i++ )
-					ret += (i==0?"":",") + GetNativeTypeNameFromSerializee( gs[i] );
+				for( int i = 0; i < td.genericArgs.Length; i++ )
+					ret += (i==0?"":",") + GetNativeTypeNameFromDescriptor( td.genericArgs[i] );
 				return ret + "]";
 			}
 			else
@@ -490,11 +478,11 @@ namespace Cilbox
 			}
 		}
 
-		public Type [] TypeNamesToArrayOfNativeTypes( Serializee [] sa )
+		public Type [] DescriptorsToArrayOfNativeTypes( SerializedTypeDescriptor [] descs )
 		{
-			Type [] ret = new Type[sa.Length];
-			for( int i = 0; i < sa.Length; i++ )
-				ret[i] = GetNativeTypeFromSerializee( sa[i] );
+			Type [] ret = new Type[descs.Length];
+			for( int i = 0; i < descs.Length; i++ )
+				ret[i] = GetNativeTypeFromDescriptor( descs[i] );
 			return ret;
 		}
 

--- a/Packages/com.cnlohr.cilbox/CilboxUtil.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxUtil.cs
@@ -945,17 +945,18 @@ namespace Cilbox
 						metaLine += Convert.ToBase64String( st["data"].AsBlob() );
 						break;
 					case MetaTokenType.mtField:
-						Type t = b.usage.GetNativeTypeFromSerializee( st["dt"] );
+						SerializedTypeDescriptor td = SerializedTypeDescriptor.FromSerializee( st["dt"] );
+						Type t = b.usage.GetNativeTypeFromDescriptor(td);
 						if( Int32.Parse( st["isStatic"].AsString() ) > 0 ) metaLine += "static ";
 						String tname = t?.ToString();
 						if( t == null )
-							tname = "NR:" + st["dt"].AsMap()["n"].AsString() + " ";
+							tname = "NR:" + td.typeName + " ";
 						metaLine += tname + st["name"].AsString();
 						break;
 					case MetaTokenType.mtType:
 					{
-						Serializee typ = st["dt"];
-						Type nt = b.usage.GetNativeTypeFromSerializee( typ );
+						SerializedTypeDescriptor td2 = SerializedTypeDescriptor.FromSerializee( st["dt"] );
+						Type nt = b.usage.GetNativeTypeFromDescriptor(td2);
 						StackType seType = StackElement.StackTypeFromType( nt );
 						if( seType < StackType.Object )
 						{
@@ -968,7 +969,7 @@ namespace Cilbox
 								bool bFound = false;
 								foreach( CilboxClass c in b.classesList )
 								{
-									if( c.className == typ.AsMap()["n"].AsString() )
+									if( c.className == td2.typeName )
 									{
 										metaLine += $"PROXY: {c.className}";
 										bFound = true;
@@ -976,7 +977,7 @@ namespace Cilbox
 								}
 
 								if( !bFound )
-									throw new Exception( $"Type {typ.AsMap()["n"].AsString()} not available." );
+									throw new Exception( $"Type {td2.typeName} not available." );
 							}
 							else
 							{
@@ -1029,7 +1030,7 @@ namespace Cilbox
 				UnityEngine.SceneManagement.Scene _scene = (UnityEngine.SceneManagement.Scene)scene;
 				if( !_scene.IsValid())
 				{
-					Debug.LogWarning($"Scene {_scene.name} is not valid. Returning empty MonoBehaviour array.");					
+					Debug.LogWarning($"Scene {_scene.name} is not valid. Returning empty MonoBehaviour array.");
 					return Array.Empty<MonoBehaviour>();
 				}
 
@@ -1092,54 +1093,6 @@ namespace Cilbox
 				t = t.DeclaringType;
 			}
 			return false;
-		}
-
-		// This does not check any rules, so it can be static.
-		public static Serializee GetSerializeeFromNativeType( Type t )
-		{
-			Dictionary< String, Serializee > ret = new Dictionary< String, Serializee >();
-			// Originally I did this to try to narrow down the search.  Now it is not as practical.
-			ret["a"] = new Serializee( t.Assembly.GetName().Name );
-			if( t.IsGenericType )
-			{
-				String genericDefName = t.GetGenericTypeDefinition().FullName;
-				StringBuilder typeNameBuilder = new StringBuilder();
-
-				// The following section strips out arity (`1, `2, etc) from the generic type definition name.
-				// This way we do not need to whitelist each generic arity of a type; We just need to whitelist the base name.
-				// Extreme example: Namespace.Outer`1+Middle`2+Inner`1 would be stripped to Namespace.Outer+Middle+Inner
-				for (int i = 0; i < genericDefName.Length; i++)
-				{
-					if (genericDefName[i] != '`')
-					{
-						typeNameBuilder.Append(genericDefName[i]);
-						continue;
-					}
-
-					int j = i + 1;
-					while (j < genericDefName.Length && char.IsDigit(genericDefName[j]))
-						j++;
-
-					if (j == genericDefName.Length || genericDefName[j] == '+' || genericDefName[j] == '[')
-						i = j - 1;
-				}
-				string baseName = typeNameBuilder.ToString();
-
-				ret["n"] = new Serializee( baseName );
-				ret["gn"] = new Serializee( genericDefName ); // Store the generic name so it does not have to be rebuilt
-				Type [] ta = t.GenericTypeArguments;
-				Serializee [] sg = new Serializee[ta.Length];
-				for( int i = 0; i < ta.Length; i++ )
-					sg[i] = GetSerializeeFromNativeType( ta[i] );
-				ret["g"] = new Serializee( sg );
-			}
-			else
-			{
-				ret["n"] = new Serializee( t.FullName );
-				if( t.IsEnum && HasCilboxableAttribute(t) )
-					ret["ut"] = GetSerializeeFromNativeType( t.GetEnumUnderlyingType() );
-			}
-			return new Serializee( ret );
 		}
 
 

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -113,7 +113,7 @@ namespace TestCilbox
 			return whiteListField.Contains( sType + "." + sFieldName );
 		}
 
-		override public bool CheckMethodAllowed( out MethodInfo mi, Type declaringType, String name, Serializee [] parametersIn, Serializee [] genericArgumentsIn, String fullSignature )
+		override public bool CheckMethodAllowed( out MethodInfo mi, Type declaringType, String name, SerializedTypeDescriptor [] parametersIn, SerializedTypeDescriptor [] genericArgumentsIn, String fullSignature )
 		{
 			mi = null;
 

--- a/TestCilbox/TestCilbox.csproj
+++ b/TestCilbox/TestCilbox.csproj
@@ -13,6 +13,7 @@
 	<ItemGroup>
 		<Compile Include="../Packages/com.cnlohr.cilbox/Cilbox.cs" />
 		<Compile Include="../Packages/com.cnlohr.cilbox/CilboxProxy.cs" />
+        <Compile Include="../Packages/com.cnlohr.cilbox/CilboxSerialization.cs" />
 		<Compile Include="../Packages/com.cnlohr.cilbox/CilboxUtil.cs" />
 		<Compile Include="../Packages/com.cnlohr.cilbox/CilboxUsage.cs" />
 	</ItemGroup>


### PR DESCRIPTION
Implement SerializedTypeDescriptor struct
* Uses Serializee under the hood; wire format is the same

Note that after this is merged, additional care will be needed to merge these changes into Basis; namely the `CheckMethodAllowed` override uses `SerializedTypeDescriptor` instead of `Serializee` and `BasisCilboxInstantiateShim.ResolveShim` will need to use `SerializedTypeDescriptor` and `DescriptorsToArrayOfNativeTypes`.
* (this is just a small code change; existing content using Cilbox is unaffected)

Note that the lines similar to 
```
SerializedTypeDescriptor td = SerializedTypeDescriptor.FromSerializee(st["dt"]);
t.nativeType = usage.GetNativeTypeFromDescriptor( td );
```
will get more concise once the outer data structures are migrated