### PR TITLE
Typed Struct Migration: Exception Handlers

### DIFF
--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -126,23 +126,22 @@ namespace Cilbox
 				handlerOffsetToClauseMap = new Dictionary<int, CilboxExceptionHandlingClause>();
 				for (int e = 0; e < ehc.Length; e++)
 				{
-					Dictionary< String, Serializee > thisehc = ehc[e].AsMap();
+					SerializedExceptionHandler seh = SerializedExceptionHandler.FromSerializee(ehc[e]);
 					CilboxExceptionHandlingClause clause = new CilboxExceptionHandlingClause();
-					clause.Flags = (ExceptionHandlingClauseOptions)Convert.ToInt32(thisehc["flags"].AsString());
-					clause.TryOffset = Convert.ToInt32(thisehc["tryOff"].AsString());
-					clause.TryLength = Convert.ToInt32(thisehc["tryLen"].AsString());
+					clause.Flags = (ExceptionHandlingClauseOptions)seh.flags;
+					clause.TryOffset = seh.tryOffset;
+					clause.TryLength = seh.tryLength;
 					clause.TryEndOffset = clause.TryOffset + clause.TryLength;
-					clause.HandlerOffset = Convert.ToInt32(thisehc["hOff"].AsString());
-					clause.HandlerLength = Convert.ToInt32(thisehc["hLen"].AsString());
+					clause.HandlerOffset = seh.handlerOffset;
+					clause.HandlerLength = seh.handlerLength;
 					clause.HandlerEndOffset = clause.HandlerOffset + clause.HandlerLength;
-					if (thisehc.TryGetValue("cType", out Serializee cTypeSer))
+					if (seh.hasCatchType)
 					{
-						SerializedTypeDescriptor td = SerializedTypeDescriptor.FromSerializee(cTypeSer);
-						clause.CatchType = parentClass.box.usage.GetNativeTypeFromDescriptor(td);
+						clause.CatchType = parentClass.box.usage.GetNativeTypeFromDescriptor(seh.catchType);
 						if (clause.CatchType == null)
 						{
 							// Check if it's a Cilboxable type
-							String typeName = thisehc["cType"].AsMap()["n"].AsString();
+							String typeName = seh.catchType.typeName;
 							if (parentClass.box.classes.ContainsKey(typeName))
 							{
 								clause.CatchTypeName = typeName;
@@ -3069,18 +3068,19 @@ spiperf.End();
 								for( int k = 0; k < exceptions.Count; k++ )
 								{
 									ExceptionHandlingClause c = exceptions[k];
-									Dictionary< String, Serializee > exc = new Dictionary< String, Serializee >();
-									exc["flags"] = new Serializee( ((int)c.Flags).ToString() );
-									exc["tryOff"] = new Serializee( c.TryOffset.ToString() );
-									exc["tryLen"] = new Serializee( c.TryLength.ToString() );
-									exc["hOff"] = new Serializee( c.HandlerOffset.ToString() );
-									exc["hLen"] = new Serializee( c.HandlerLength.ToString() );
+									SerializedExceptionHandler seh =  new SerializedExceptionHandler();
+									seh.flags = (int)c.Flags;
+									seh.tryOffset = c.TryOffset;
+									seh.tryLength = c.TryLength;
+									seh.handlerOffset = c.HandlerOffset;
+									seh.handlerLength = c.HandlerLength;
 
 									if( c.Flags == ExceptionHandlingClauseOptions.Clause && c.CatchType != null )
 									{
-										exc["cType"] = SerializedTypeDescriptorBuilder.FromNativeType( c.CatchType ).ToSerializee();
+										seh.hasCatchType = true;
+										seh.catchType = SerializedTypeDescriptorBuilder.FromNativeType( c.CatchType );
 									}
-									excArray[k] = new Serializee( exc );
+									excArray[k] = seh.ToSerializee();
 								}
 								MethodProps["eh"] = new Serializee( excArray );
 							}

--- a/Packages/com.cnlohr.cilbox/CilboxSerialization.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxSerialization.cs
@@ -73,6 +73,48 @@ namespace Cilbox
 		}
 	}
 
+	public class SerializedExceptionHandler
+	{
+		public int flags;
+		public int tryOffset;
+		public int tryLength;
+		public int handlerOffset;
+		public int handlerLength;
+		public bool hasCatchType;
+		public SerializedTypeDescriptor catchType;
+
+		public Serializee ToSerializee()
+		{
+			Dictionary<String, Serializee> ret = new Dictionary<String, Serializee>();
+			ret["flags"] = new Serializee(flags.ToString());
+			ret["tryOff"] = new Serializee(tryOffset.ToString());
+			ret["tryLen"] = new Serializee(tryLength.ToString());
+			ret["hOff"] = new Serializee(handlerOffset.ToString());
+			ret["hLen"] = new Serializee(handlerLength.ToString());
+			if (hasCatchType)
+				ret["cType"] = catchType.ToSerializee();
+			return new Serializee(ret);
+		}
+
+		public static SerializedExceptionHandler FromSerializee(Serializee s)
+		{
+			Dictionary<String, Serializee> m = s.AsMap();
+			SerializedExceptionHandler eh = new SerializedExceptionHandler();
+			eh.flags = Int32.Parse(m["flags"].AsString());
+			eh.tryOffset = Int32.Parse(m["tryOff"].AsString());
+			eh.tryLength = Int32.Parse(m["tryLen"].AsString());
+			eh.handlerOffset = Int32.Parse(m["hOff"].AsString());
+			eh.handlerLength = Int32.Parse(m["hLen"].AsString());
+			if (m.TryGetValue("cType", out Serializee cType))
+			{
+				eh.hasCatchType = true;
+				eh.catchType = SerializedTypeDescriptor.FromSerializee( cType );
+			}
+
+			return eh;
+		}
+	}
+
 	/// <summary>
 	/// Helper to build a SerializedTypeDescriptor from a native System.Type.
 	/// Used by the editor compiler to build type descriptors from native System.Type.


### PR DESCRIPTION
Implement SerializedExceptionHandler struct
* Uses Serializee under the hood; wire format is the same