### PR TITLE
re-add typed struct modifications to Assets

### DIFF
--- a/Assets/CilboxAvatar.cs
+++ b/Assets/CilboxAvatar.cs
@@ -91,7 +91,7 @@ namespace Cilbox
 		}
 
 		// After a type is allowed, this is called to see if the specific method is OK.
-		override public bool CheckMethodAllowed( out MethodInfo mi, Type declaringType, String name, Serializee [] parametersIn, Serializee [] genericArgumentsIn, String fullSignature )
+		override public bool CheckMethodAllowed( out MethodInfo mi, Type declaringType, String name, SerializedTypeDescriptor [] parametersIn, SerializedTypeDescriptor [] genericArgumentsIn, String fullSignature )
 		{
 			mi = null;
 

--- a/Assets/CilboxScene.cs
+++ b/Assets/CilboxScene.cs
@@ -99,7 +99,7 @@ namespace Cilbox
 		}
 
 		// After a type is allowed, this is called to see if the specific method is OK.
-		override public bool CheckMethodAllowed( out MethodInfo mi, Type declaringType, String name, Serializee [] parametersIn, Serializee [] genericArgumentsIn, String fullSignature )
+		override public bool CheckMethodAllowed( out MethodInfo mi, Type declaringType, String name, SerializedTypeDescriptor [] parametersIn, SerializedTypeDescriptor [] genericArgumentsIn, String fullSignature )
 		{
 			mi = null;
 


### PR DESCRIPTION
Not sure how these changes escaped this PR: https://github.com/cnlohr/cilbox/pull/110
I may have reset the Assets folder by mistake before pushing..

These changes are required to load the scene in Unity. As mentioned in the #110 description, this change will need to occur in the next merge to Basis (or other consumers), but it doesn't affect existing serialized content at all.
