### PR TITLE
Typed Struct Migration: Enum

### DIFF
--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -2274,23 +2274,20 @@ spiperf.End();
 			}
 
 			cilboxEnums = new Dictionary<string, CilboxEnum>();
-			Serializee enumsSer;
-			if (assemblyRoot.TryGetValue("enums", out enumsSer))
+			if (assemblyRoot.TryGetValue("enums", out Serializee enumsSer))
 			{
 				foreach (var kv in enumsSer.AsMap())
 				{
-					var enumProps = kv.Value.AsMap();
+					SerializedEnum se = SerializedEnum.FromSerializee(kv.Value, kv.Key);
 					CilboxEnum ce = new CilboxEnum();
-					ce.enumName = kv.Key;
-					SerializedTypeDescriptor td = SerializedTypeDescriptor.FromSerializee(enumProps["ut"]);
-					ce.underlyingType = StackElement.StackTypeFromType(usage.GetNativeTypeFromDescriptor(td));
+					ce.enumName = se.enumName;
+					ce.underlyingType = StackElement.StackTypeFromType(usage.GetNativeTypeFromDescriptor(se.underlyingType));
 					ce.valueToName = new Dictionary<long, string>();
-					foreach (var entry in enumProps["values"].AsArray())
+					foreach (var entry in se.values)
 					{
-						var e = entry.AsMap();
-						ce.valueToName[Convert.ToInt64(e["v"].AsString())] = e["n"].AsString();
+						ce.valueToName[entry.value] = entry.name;
 					}
-					cilboxEnums[kv.Key] = ce;
+					cilboxEnums[se.enumName] = ce;
 				}
 			}
 
@@ -3158,20 +3155,21 @@ spiperf.End();
 				{
 					if (!type.IsEnum || !CilboxUtil.HasCilboxableAttribute(type))
 						continue;
-					Dictionary< String, Serializee > enumProps = new Dictionary< String, Serializee >();
-					enumProps["ut"] = SerializedTypeDescriptorBuilder.FromNativeType(type.GetEnumUnderlyingType()).ToSerializee();
+					SerializedEnum serializedEnum  = new SerializedEnum();
+					serializedEnum.enumName = type.FullName;
+					serializedEnum.underlyingType = SerializedTypeDescriptorBuilder.FromNativeType(type.GetEnumUnderlyingType());
 					string[] names = Enum.GetNames(type);
 					Array values = Enum.GetValues(type);
-					Serializee[] entries = new Serializee[names.Length];
+					SerializedEnumValue[] entries = new  SerializedEnumValue[names.Length];
 					for (int i = 0; i < names.Length; i++)
 					{
-						Dictionary< String, Serializee > entry = new Dictionary< String, Serializee >();
-						entry["n"] = new Serializee(names[i]);
-						entry["v"] = new Serializee(Convert.ToInt64(values.GetValue(i)).ToString());
-						entries[i] = new Serializee(entry);
+						SerializedEnumValue entry = new SerializedEnumValue();
+						entry.name = names[i];
+						entry.value = Convert.ToInt64(values.GetValue(i));
+						entries[i] = entry;
 					}
-					enumProps["values"] = new Serializee(entries);
-					enumsDict[type.FullName] = new Serializee(enumProps);
+					serializedEnum.values = entries;
+					enumsDict[type.FullName] = serializedEnum.ToSerializee();
 				}
 			}
 

--- a/Packages/com.cnlohr.cilbox/CilboxSerialization.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxSerialization.cs
@@ -324,6 +324,61 @@ namespace Cilbox
 		}
 	}
 
+	public class SerializedEnumValue
+	{
+		public string name;
+		public long value;
+
+		public Serializee ToSerializee()
+		{
+			Dictionary<String, Serializee> ret = new Dictionary<String, Serializee>();
+			ret["n"] = new Serializee( name );
+			ret["v"] = new Serializee( value.ToString() );
+			return new Serializee( ret );
+		}
+
+		public static SerializedEnumValue FromSerializee( Serializee s )
+		{
+			Dictionary<String, Serializee> m = s.AsMap();
+			SerializedEnumValue v = new SerializedEnumValue();
+			v.name = m["n"].AsString();
+			v.value = Int64.Parse( m["v"].AsString() );
+			return v;
+		}
+	}
+
+	public class SerializedEnum
+	{
+		public string enumName;
+		public SerializedTypeDescriptor underlyingType;
+		public SerializedEnumValue[] values;
+
+		// enumName is the enclosing Map key. Master enumProps order: ut, values.
+		public Serializee ToSerializee()
+		{
+			Dictionary<String, Serializee> ret = new Dictionary<String, Serializee>();
+			ret["ut"] = underlyingType.ToSerializee();
+			Serializee[] vals = new Serializee[values.Length];
+			for( int i = 0; i < values.Length; i++ )
+				vals[i] = values[i].ToSerializee();
+			ret["values"] = new Serializee( vals );
+			return new Serializee( ret );
+		}
+
+		public static SerializedEnum FromSerializee( Serializee s, String enumName )
+		{
+			Dictionary<String, Serializee> m = s.AsMap();
+			SerializedEnum e = new SerializedEnum();
+			e.enumName = enumName;
+			e.underlyingType = SerializedTypeDescriptor.FromSerializee( m["ut"] );
+			Serializee[] vals = m["values"].AsArray();
+			e.values = new SerializedEnumValue[vals.Length];
+			for( int i = 0; i < vals.Length; i++ )
+				e.values[i] = SerializedEnumValue.FromSerializee( vals[i] );
+			return e;
+		}
+	}
+
 	/// <summary>
 	/// Helper to build a SerializedTypeDescriptor from a native System.Type.
 	/// Used by the editor compiler to build type descriptors from native System.Type.


### PR DESCRIPTION
Implement SerializedEnum / SerializedEnumValue structs
* Uses Serializee under the hood; wire format is the same