### PR TITLE
Typed Struct Migration: Assembly

### DIFF
--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -2247,15 +2247,17 @@ spiperf.End();
 			timeoutLengthUs = desiredTimeoutLengthUs; // make sure min is applied once.
 
 			SerializedAssembly assembly = SerializedAssembly.DeserializeString( assemblyData );
+			SerializedClass[] classData = assembly.classes;
+			SerializedMetadataToken[] metaData = assembly.metadata;
 
-			metadatas = new CilMetadataTokenInfo[assembly.metadata.Length + 1]; // element 0 is invalid.
+			metadatas = new CilMetadataTokenInfo[metaData.Length + 1]; // element 0 is invalid.
 			metadatas[0] = new CilMetadataTokenInfo( 0 );
 			metadatas[0].Name = "<INVALID>";
 
 			int clsid = 0;
 			classes = new Dictionary< String, int >();
-			classesList = new CilboxClass[assembly.classes.Length];
-			foreach( var sc in assembly.classes )
+			classesList = new CilboxClass[classData.Length];
+			foreach( var sc in classData )
 			{
 				classesList[clsid] = new CilboxClass();
 				classes[sc.className] = clsid;
@@ -2265,7 +2267,7 @@ spiperf.End();
 			// Actually load classes in a 2nd pass so we know which classes are Cilbox types first
 			for (int i = 0; i < clsid; i++)
 			{
-				classesList[i].LoadCilboxClass( this, assembly.classes[i] );
+				classesList[i].LoadCilboxClass( this, classData[i] );
 			}
 
 			cilboxEnums = new Dictionary<string, CilboxEnum>();
@@ -2285,7 +2287,7 @@ spiperf.End();
 				}
 			}
 
-			foreach( var st in assembly.metadata )
+			foreach( var st in metaData )
 			{
 				MetaTokenType metatype = (MetaTokenType)st.metaTokenType;
 				CilMetadataTokenInfo t = metadatas[st.metaTokenIndex] = new CilMetadataTokenInfo( metatype );

--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -17,6 +17,7 @@ using UnityEditor;
 using UnityEditor.Build;
 using UnityEditor.Callbacks;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 #endif
 
@@ -2245,24 +2246,18 @@ spiperf.End();
 			//Debug.Log( "Cilbox Initialize Metadata:" + assemblyData.Length );
 			timeoutLengthUs = desiredTimeoutLengthUs; // make sure min is applied once.
 
-			Dictionary< String, Serializee > assemblyRoot = new Serializee( Convert.FromBase64String( assemblyData ), Serializee.ElementType.Map ).AsMap();
-			Dictionary< String, Serializee > classData = assemblyRoot["classes"].AsMap();
-			Dictionary< String, Serializee > metaData = assemblyRoot["metadata"].AsMap();
+			SerializedAssembly assembly = SerializedAssembly.DeserializeString( assemblyData );
 
-			metadatas = new CilMetadataTokenInfo[metaData.Count+1]; // element 0 is invalid.
+			metadatas = new CilMetadataTokenInfo[assembly.metadata.Length + 1]; // element 0 is invalid.
 			metadatas[0] = new CilMetadataTokenInfo( 0 );
 			metadatas[0].Name = "<INVALID>";
 
 			int clsid = 0;
 			classes = new Dictionary< String, int >();
-			classesList = new CilboxClass[classData.Count];
-			SerializedClass[] scArr = new SerializedClass[classData.Count];
-			foreach( var v in classData )
+			classesList = new CilboxClass[assembly.classes.Length];
+			foreach( var sc in assembly.classes )
 			{
-				CilboxClass cls = new CilboxClass();
-				SerializedClass sc  = SerializedClass.FromSerializee(v.Value, v.Key);
-				scArr[clsid] = sc;
-				classesList[clsid] = cls;
+				classesList[clsid] = new CilboxClass();
 				classes[sc.className] = clsid;
 				clsid++;
 			}
@@ -2270,15 +2265,14 @@ spiperf.End();
 			// Actually load classes in a 2nd pass so we know which classes are Cilbox types first
 			for (int i = 0; i < clsid; i++)
 			{
-				classesList[i].LoadCilboxClass( this, scArr[i] );
+				classesList[i].LoadCilboxClass( this, assembly.classes[i] );
 			}
 
 			cilboxEnums = new Dictionary<string, CilboxEnum>();
-			if (assemblyRoot.TryGetValue("enums", out Serializee enumsSer))
+			if (assembly.enums.Length > 0)
 			{
-				foreach (var kv in enumsSer.AsMap())
+				foreach (var se in assembly.enums)
 				{
-					SerializedEnum se = SerializedEnum.FromSerializee(kv.Value, kv.Key);
 					CilboxEnum ce = new CilboxEnum();
 					ce.enumName = se.enumName;
 					ce.underlyingType = StackElement.StackTypeFromType(usage.GetNativeTypeFromDescriptor(se.underlyingType));
@@ -2291,9 +2285,8 @@ spiperf.End();
 				}
 			}
 
-			foreach( var v in metaData )
+			foreach( var st in assembly.metadata )
 			{
-				SerializedMetadataToken st = SerializedMetadataToken.FromSerializee(v.Value, v.Key);
 				MetaTokenType metatype = (MetaTokenType)st.metaTokenType;
 				CilMetadataTokenInfo t = metadatas[st.metaTokenIndex] = new CilMetadataTokenInfo( metatype );
 
@@ -2672,7 +2665,7 @@ spiperf.End();
 
 			uint mdcount = 1; // token 0 is invalid.
 			int bytecodeLength = 0;
-			Dictionary< String, Serializee > classes = new Dictionary<String, Serializee>();
+			List<SerializedClass> classes = new List<SerializedClass>();
 			Dictionary< String, SerializedMethod[] > allClassMethods = new Dictionary< String, SerializedMethod[] >();
 
 			perf.End(); perf = new ProfilerMarker( "Main Getting Types" ); perf.Begin();
@@ -3116,14 +3109,14 @@ spiperf.End();
 						if( CilboxUtil.HasCilboxableAttribute( bt ) )
 							baseClassChain.Add( bt.FullName );
 					serializedClass.baseClassNames = baseClassChain.ToArray();
-					classes[type.FullName] = serializedClass.ToSerializee();
+					classes.Add(serializedClass);
 					perfType.End();
 				}
 			}
 
 			perf.End(); perf = new ProfilerMarker( "Assembling" ); perf.Begin();
 
-			Dictionary< String, Serializee > enumsDict = new Dictionary< String, Serializee >();
+			List<SerializedEnum> enums = new List<SerializedEnum>();
 			foreach( System.Reflection.Assembly proxyAssembly in assys )
 			{
 				foreach (Type type in proxyAssembly.GetTypes())
@@ -3144,25 +3137,20 @@ spiperf.End();
 						entries[i] = entry;
 					}
 					serializedEnum.values = entries;
-					enumsDict[type.FullName] = serializedEnum.ToSerializee();
+					enums.Add(serializedEnum);
 				}
 			}
 
-			Dictionary< String, Serializee > assemblyMetadataDict = new Dictionary< String, Serializee >();
-			foreach (var v in assemblyMetadata)
+			SerializedAssembly assembly = new SerializedAssembly
 			{
-				assemblyMetadataDict[v.Value.metaTokenIndex.ToString()] = v.Value.ToSerializee();
-			}
-
-			Dictionary< String, Serializee > assemblyRoot = new Dictionary< String, Serializee >();
-			assemblyRoot["classes"] = new Serializee( classes );
-			assemblyRoot["metadata"] = new Serializee( assemblyMetadataDict );
-			assemblyRoot["enums"] = new Serializee( enumsDict );
-			Serializee assemblySerializee = new Serializee( assemblyRoot );
+				classes = classes.ToArray(),
+				metadata = assemblyMetadata.Values.ToArray(),
+				enums = enums.ToArray(),
+			};
 
 			perf.End(); perf = new ProfilerMarker( "Serializing" ); perf.Begin();
 
-			String sAllAssemblyData = Convert.ToBase64String(assemblySerializee.DumpAsMemory().ToArray() );
+			String sAllAssemblyData = assembly.SerializeString();
 
 			perf.End(); perf = new ProfilerMarker( "Checking If Assembly Changed" ); perf.Begin();
 

--- a/Packages/com.cnlohr.cilbox/CilboxSerialization.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxSerialization.cs
@@ -529,6 +529,74 @@ namespace Cilbox
 		}
 	}
 
+	public class SerializedAssembly
+	{
+		public SerializedClass[] classes;
+		public SerializedMetadataToken[] metadata;
+		public SerializedEnum[] enums;
+
+		// Root Map order: classes (keyed className), metadata (keyed by string
+		// token index starting at 1), enums (keyed enumName). base64 of the
+		// Serializee buffer, byte-for-byte identical to master's assemblyData.
+		public string SerializeString()
+		{
+			Dictionary<String, Serializee> root = new Dictionary<String, Serializee>();
+
+			Dictionary<String, Serializee> cl = new Dictionary<String, Serializee>();
+			for( int i = 0; i < classes.Length; i++ )
+				cl[classes[i].className] = classes[i].ToSerializee();
+			root["classes"] = new Serializee( cl );
+
+			Dictionary<String, Serializee> md = new Dictionary<String, Serializee>();
+			for( int i = 0; i < metadata.Length; i++ )
+				md[(metadata[i].metaTokenIndex).ToString()] = metadata[i].ToSerializee();
+			root["metadata"] = new Serializee( md );
+
+			Dictionary<String, Serializee> en = new Dictionary<String, Serializee>();
+			for( int i = 0; i < enums.Length; i++ )
+				en[enums[i].enumName] = enums[i].ToSerializee();
+			root["enums"] = new Serializee( en );
+
+			return Convert.ToBase64String( new Serializee( root ).DumpAsMemory().ToArray() );
+		}
+
+		public static SerializedAssembly DeserializeString( string base64 )
+		{
+			SerializedAssembly asm = new SerializedAssembly();
+			Dictionary<String, Serializee> root =
+				new Serializee( Convert.FromBase64String( base64 ), Serializee.ElementType.Map ).AsMap();
+
+			Dictionary<String, Serializee> cl = root["classes"].AsMap();
+			asm.classes = new SerializedClass[cl.Count];
+			int ci = 0;
+			foreach( KeyValuePair<String, Serializee> kv in cl )
+				asm.classes[ci++] = SerializedClass.FromSerializee( kv.Value, kv.Key );
+
+			Dictionary<String, Serializee> md = root["metadata"].AsMap();
+			asm.metadata = new SerializedMetadataToken[md.Count];
+			foreach( KeyValuePair<String, Serializee> kv in md )
+			{
+				var smt = SerializedMetadataToken.FromSerializee(kv.Value, kv.Key);
+				asm.metadata[smt.metaTokenIndex - 1] = smt; // serializee is in a 1-based dict, but store it in a regular 0-based flat array here
+			}
+
+			if( root.TryGetValue( "enums", out Serializee enumsS ) )
+			{
+				Dictionary<String, Serializee> en = enumsS.AsMap();
+				asm.enums = new SerializedEnum[en.Count];
+				int ei = 0;
+				foreach( KeyValuePair<String, Serializee> kv in en )
+					asm.enums[ei++] = SerializedEnum.FromSerializee( kv.Value, kv.Key );
+			}
+			else
+			{
+				asm.enums = new SerializedEnum[0];
+			}
+
+			return asm;
+		}
+	}
+
 	/// <summary>
 	/// Helper to build a SerializedTypeDescriptor from a native System.Type.
 	/// Used by the editor compiler to build type descriptors from native System.Type.

--- a/Packages/com.cnlohr.cilbox/CilboxUsage.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxUsage.cs
@@ -254,9 +254,9 @@ namespace Cilbox
 // This is no longer done here, but stands as an example of how you could use this function.
 //			if( typeName == "<PrivateImplementationDetails>" && name == "ComputeStringHash" )
 //			{
-//				Dictionary< String, Serializee > exportType = new Dictionary< String, Serializee >();
-//				exportType["n"] = new Serializee( "Cilbox.CilboxPublicUtils" );
-//				return ( "ComputeStringHashProxy", new Serializee( exportType ) );
+//				SerializedTypeDescriptor exportType = new SerializedTypeDescriptor();
+//				exportType.typeName = "Cilbox.CilboxPublicUtils";
+//				return ( "ComputeStringHashProxy", exportType );
 //				//return ( "ComputeStringHashProxy", declaringType );
 //			}
 

--- a/Packages/com.cnlohr.cilbox/CilboxUtil.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxUtil.cs
@@ -762,23 +762,24 @@ namespace Cilbox
 				CilboxClass [] classesList;
 
 				SerializedAssembly assembly = SerializedAssembly.DeserializeString(assemblyData);
+				SerializedClass[] classData = assembly.classes;
+				SerializedMetadataToken[] metaData = assembly.metadata;
 
 				int clsid = 0;
 				classes = new Dictionary< String, int >();
-				classesList = new CilboxClass[assembly.classes.Length];
-				for( int i = 0; i < assembly.classes.Length; i++ )
+				classesList = new CilboxClass[classData.Length];
+				for( int i = 0; i < classData.Length; i++ )
 				{
-					CilboxClass cls = new CilboxClass();
-					classesList[clsid] = cls;
-					classes[assembly.classes[i].className] = clsid;
+					classesList[clsid] = new CilboxClass();
+					classes[classData[i].className] = clsid;
 					clsid++;
 				}
 
 				clsid = 0;
-				for( int cid = 0; cid < assembly.classes.Length; cid++ )
+				for( int cid = 0; cid < classData.Length; cid++ )
 				{
 					CilboxClass c = classesList[clsid++];
-					SerializedClass sc = assembly.classes[cid];
+					SerializedClass sc = classData[cid];
 					c.LoadCilboxClass( b, sc );
 
 					CLog.WriteLine( $"Class: {c.className}" );
@@ -922,7 +923,7 @@ namespace Cilbox
 					}
 				}
 
-				foreach( var st in assembly.metadata )
+				foreach( var st in metaData )
 				{
 					MetaTokenType metatype = (MetaTokenType)st.metaTokenType;
 

--- a/Packages/com.cnlohr.cilbox/CilboxUtil.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxUtil.cs
@@ -761,27 +761,24 @@ namespace Cilbox
 				Dictionary< String, int > classes;
 				CilboxClass [] classesList;
 
-				Dictionary< String, Serializee > assemblyRoot = new Serializee( Convert.FromBase64String( assemblyData ), Serializee.ElementType.Map ).AsMap();
-				Dictionary< String, Serializee > classData = assemblyRoot["classes"].AsMap();
-				Dictionary< String, Serializee > metaData = assemblyRoot["metadata"].AsMap();
+				SerializedAssembly assembly = SerializedAssembly.DeserializeString(assemblyData);
 
 				int clsid = 0;
 				classes = new Dictionary< String, int >();
-				classesList = new CilboxClass[classData.Count];
-				foreach( var v in classData )
+				classesList = new CilboxClass[assembly.classes.Length];
+				for( int i = 0; i < assembly.classes.Length; i++ )
 				{
 					CilboxClass cls = new CilboxClass();
 					classesList[clsid] = cls;
-					classes[(String)v.Key] = clsid;
+					classes[assembly.classes[i].className] = clsid;
 					clsid++;
 				}
 
 				clsid = 0;
-				foreach( var v in classData )
+				for( int cid = 0; cid < assembly.classes.Length; cid++ )
 				{
 					CilboxClass c = classesList[clsid++];
-
-					SerializedClass sc = SerializedClass.FromSerializee( v.Value, v.Key );
+					SerializedClass sc = assembly.classes[cid];
 					c.LoadCilboxClass( b, sc );
 
 					CLog.WriteLine( $"Class: {c.className}" );
@@ -925,38 +922,32 @@ namespace Cilbox
 					}
 				}
 
-				foreach( var v in metaData )
+				foreach( var st in assembly.metadata )
 				{
-					int mid = Convert.ToInt32((String)v.Key);
-					Dictionary< String, Serializee > st = v.Value.AsMap();
-					MetaTokenType metatype = (MetaTokenType)Convert.ToInt32(st["mt"].AsString());
-					//CilMetadataTokenInfo t = metadatas[mid] = new CilMetadataTokenInfo( metatype );
+					MetaTokenType metatype = (MetaTokenType)st.metaTokenType;
 
-					//t.type = metatype;
-					//t.Name = "<UNKNOWN>";
-
-					String metaLine = $"\t{mid.ToString("X4")} {metatype.ToString().Substring(2),-7} ";
+					String metaLine = $"\t{st.metaTokenIndex.ToString("X4")} {metatype.ToString().Substring(2),-7} ";
 
 					switch( metatype )
 					{
 					case MetaTokenType.mtString:
-						metaLine += st["s"].AsString();
+						metaLine += st.stringValue;
 						break;
 					case MetaTokenType.mtArrayInitializer:
-						metaLine += Convert.ToBase64String( st["data"].AsBlob() );
+						metaLine += Convert.ToBase64String( st.arrayInitData );
 						break;
 					case MetaTokenType.mtField:
-						SerializedTypeDescriptor td = SerializedTypeDescriptor.FromSerializee( st["dt"] );
+						SerializedTypeDescriptor td = st.typeDescriptor;
 						Type t = b.usage.GetNativeTypeFromDescriptor(td);
-						if( Int32.Parse( st["isStatic"].AsString() ) > 0 ) metaLine += "static ";
+						if( st.isStatic ) metaLine += "static ";
 						String tname = t?.ToString();
 						if( t == null )
 							tname = "NR:" + td.typeName + " ";
-						metaLine += tname + st["name"].AsString();
+						metaLine += tname + st.name;
 						break;
 					case MetaTokenType.mtType:
 					{
-						SerializedTypeDescriptor td2 = SerializedTypeDescriptor.FromSerializee( st["dt"] );
+						SerializedTypeDescriptor td2 = st.typeDescriptor;
 						Type nt = b.usage.GetNativeTypeFromDescriptor(td2);
 						StackType seType = StackElement.StackTypeFromType( nt );
 						if( seType < StackType.Object )
@@ -989,7 +980,7 @@ namespace Cilbox
 					}
 					case MetaTokenType.mtMethod:
 					{
-						metaLine += $"{st["name"].AsString()} {st["fullSignature"].AsString()} {st["assembly"].AsString()}";
+						metaLine += $"{st.name} {st.methodFullSignature} {st.methodAssembly}";
 						break;
 					}
 					}
@@ -1006,7 +997,7 @@ namespace Cilbox
 		}
 
 		// Layout enumeration only -- field TYPES are not gated here. Every field type (inherited privates included) is
-		// validated at load in CilboxClass.LoadCilboxClass (GetNativeTypeFromSerializee -> CheckTypeAllowed), the real boundary.
+		// validated at load in CilboxClass.LoadCilboxClass (GetNativeTypeFromDescriptor -> CheckTypeAllowed), the real boundary.
 		public static FieldInfo[] GetInstanceFieldsBaseFirst( Type type )
 		{
 			List< FieldInfo > ordered = new List< FieldInfo >();


### PR DESCRIPTION
Implement SerializedAssembly struct
* Uses the same b64 string format via Serializee

This is the last piece of the main assembly.

After this is just CilboxProxy which might be 1 PR.
