### PR TITLE
Typed Struct Migration: Proxy

### DIFF
--- a/Packages/com.cnlohr.cilbox/CilboxProxy.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxProxy.cs
@@ -336,11 +336,7 @@ namespace Cilbox
 						continue;
 					}
 
-					bool bIsObject = LoadObjectFromProxyField( spf, out object o, cls.instanceFieldNames[i] );
-					if( bIsObject )
-						fields[i].LoadObject( o );
-					else
-						fields[i].Load( o );
+					LoadProxyFieldStackElement( spf, ref fields[i], cls.instanceFieldNames[i] );
 				}
 
 
@@ -357,8 +353,8 @@ namespace Cilbox
 		}
 
 
-		// Returns: true if is object, otherwise is primitive.
-		private bool LoadObjectFromProxyField( SerializedProxyField spf, out object oOut, String rootFieldName )
+		// Loads the reference StackElement with the appropriate data
+		private void LoadProxyFieldStackElement( SerializedProxyField spf, ref StackElement refElement, String rootFieldName )
 		{
 			ProxyFieldType ft = (ProxyFieldType)spf.fieldType;
 			List<UnityEngine.Object> objectSlots = runtimeFieldsObjects ?? fieldsObjects;
@@ -378,9 +374,9 @@ namespace Cilbox
 
 				if (spf.objectRefIsNull)
 				{
-					// This field was null when serialized, so just return null
-					oOut = null;
-					return true;
+					// This field was null when serialized, so just load null
+					refElement.LoadObject(null);
+					return;
 				}
 
 				UnityEngine.Object o = objectSlots[iFO];
@@ -390,12 +386,12 @@ namespace Cilbox
 					if (o is CilboxProxy cilboxProxy)
 						cilboxProxy.RuntimeProxyLoad();
 
-					oOut = o;
+					refElement.LoadObject(o);
 
 					// Remove reference out of the fieldsObjects array.
 					objectSlots[iFO] = null;
 
-					return true;
+					return;
 				}
 
 				Debug.LogWarning(
@@ -419,8 +415,8 @@ namespace Cilbox
 					}
 					else // type is null and not a Cilbox class
 					{
-						oOut = null;
-						return true;
+						refElement.LoadObject(null);
+						return;
 					}
 				}
 
@@ -460,49 +456,33 @@ namespace Cilbox
 				{
 					for( int j = 0; j < aLen; j++ )
 					{
-						LoadObjectFromProxyField( spf.arrayElements[j], out object o, rootFieldName );
-						arr.SetValue( o, j );
+						StackElement temp = default;
+						LoadProxyFieldStackElement( spf.arrayElements[j], ref temp, rootFieldName );
+						arr.SetValue( temp.AsObject(), j );
 					}
 				}
 
-				oOut = arr;
-				return true;
+				refElement.LoadObject(arr);
+				return;
 			}
 
 			case ProxyFieldType.String:
 			{
-				oOut = spf.data;
-				return false;
+				refElement.LoadObject(spf.data);
+				return;
 			}
 
 			case ProxyFieldType.Primitive:
 			{
-				// Slow path — only reached if a caller didn't short-circuit. Re-boxes from the
-				// 16-byte PrimitivePayload (no object slot, so the StackElement.AsObject branches
-				// for Address/NativeHandle/Object don't apply here).
-				oOut = spf.primitiveValue.type switch
-				{
-					StackType.Boolean => spf.primitiveValue.b,
-					StackType.Sbyte => (sbyte)spf.primitiveValue.l,
-					StackType.Byte => (byte)spf.primitiveValue.e,
-					StackType.Short => (short)spf.primitiveValue.l,
-					StackType.Ushort => (ushort)spf.primitiveValue.e,
-					StackType.Int => (int)spf.primitiveValue.l,
-					StackType.Uint => (uint)spf.primitiveValue.e,
-					StackType.Long => spf.primitiveValue.l,
-					StackType.Ulong => spf.primitiveValue.e,
-					StackType.Float => spf.primitiveValue.f,
-					StackType.Double => spf.primitiveValue.d,
-					_ => throw new NotSupportedException($"PrimitivePayload cannot box StackType {spf.primitiveValue.type}")
-				};
-				return false;
+				spf.primitiveValue.ToStackElement(ref refElement);
+				return;
 			}
 
 			case ProxyFieldType.Json:
 			{
 				Type t = box.usage.GetNativeTypeFromDescriptor( spf.elementType );
-				oOut = JsonUtility.FromJson(spf.data, t);
-				return true;
+				refElement.LoadObject(JsonUtility.FromJson(spf.data, t));
+				return;
 			}
 
 			case ProxyFieldType.Empty:
@@ -510,8 +490,7 @@ namespace Cilbox
 				break;
 			}
 
-			oOut = null;
-			return false;
+			refElement.LoadObject(null);
 		}
 
 

--- a/Packages/com.cnlohr.cilbox/CilboxProxy.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxProxy.cs
@@ -54,7 +54,7 @@ namespace Cilbox
 			fieldsObjects = new List< UnityEngine.Object >();
 			FieldInfo[] fi = CilboxUtil.GetInstanceFieldsBaseFirst( mToSteal.GetType() );
 
-			List< Serializee > lstObjects = new List< Serializee >();
+			List< SerializedProxyField > lstFields = new List< SerializedProxyField >();
 
 			foreach( var f in fi )
 			{
@@ -80,50 +80,37 @@ namespace Cilbox
 					continue;
 				}
 
-				Serializee e = SerializeThing( fv, f.Name, matchingInstanceNameID, ref refToProxyMap );
+				SerializedProxyField spf = SerializeProxyField(fv, f.Name, matchingInstanceNameID, ref refToProxyMap);
 
 				// Serialize no matter what.
-				lstObjects.Add( e );
+				lstFields.Add( spf );
 			}
 
-			serializedObjectData =
-				Convert.ToBase64String(new Serializee(lstObjects.ToArray()).DumpAsMemory().ToArray());
+			SerializedProxy proxy = new SerializedProxy
+			{
+				fields = lstFields.ToArray(),
+			};
+			serializedObjectData = proxy.SerializeString();
 
 			buildTimeGuid = Guid.NewGuid().ToString();
-
-			//Debug.Log( $"SERIALIZE --> {serializedObjectData}" );
 		}
 
 
-		private Serializee SerializeThing( object fv, String fName, int matchingInstanceNameID, ref Dictionary< MonoBehaviour, CilboxProxy > refToProxyMap )
+		private SerializedProxyField SerializeProxyField( object fv, String fName, int matchingInstanceNameID, ref Dictionary< MonoBehaviour, CilboxProxy > refToProxyMap )
 		{
-			Dictionary<String, Serializee> instanceFields = new Dictionary<String, Serializee>();
-
-			// "n" is the "name" of the variable, only useful for object-root objects.
-			// "miid" = Field ID.
-			// "t" = Type
-			// "d" = Data (If applicable) (For strings and StackElements)
+			SerializedProxyField spf = new SerializedProxyField();
+			spf.fieldName = fName;
+			spf.matchingInstanceId = matchingInstanceNameID;
 
 			// Skip null objects.
 			if( fv == null )
 			{
-				instanceFields["empty"] = new Serializee( "true" );
-				return new Serializee(instanceFields);
+				spf.fieldType = (byte)ProxyFieldType.Empty;
+				return spf;
 			}
 
 			Type fvType = fv.GetType();
 			bool hasCilboxable = CilboxUtil.HasCilboxableAttribute( fvType );
-
-
-			if( fName != null )
-			{
-				instanceFields["n"] = new Serializee(fName);
-			}
-
-			if( matchingInstanceNameID >= 0 )
-			{
-				instanceFields["miid"] = new Serializee(matchingInstanceNameID.ToString());
-			}
 
 			StackType st;
 
@@ -131,65 +118,61 @@ namespace Cilbox
 			if( fvType.IsEnum )
 			{
 				object underlying = Convert.ChangeType( fv, fvType.GetEnumUnderlyingType() );
-				if( StackElement.TypeToStackType.TryGetValue( fvType.ToString(), out st ) && st < StackType.Object )
+				if( StackElement.TypeToStackType.TryGetValue( underlying.GetType().ToString(), out st ) && st < StackType.Object )
 				{
-					instanceFields["d"] = new Serializee(underlying.ToString());
-					instanceFields["t"] = new Serializee("e" + st);
+					spf.fieldType = (byte)ProxyFieldType.Primitive;
+					spf.primitiveValue.Unbox( underlying, st );
 				}
 			}
 			// Not a proxiable script.
 			else if (hasCilboxable)
 			{
-				// This is a cilboxable thing.
-				instanceFields["fo"] = new Serializee(fieldsObjects.Count.ToString());
+				spf.fieldType = (byte)ProxyFieldType.CilboxRef;
+				spf.fieldObjectIndex = fieldsObjects.Count;
+				spf.objectRefName = fv.ToString();
+				spf.objectRefIsNull = spf.objectRefName == "null";
 				fieldsObjects.Add( refToProxyMap[(MonoBehaviour)fv] );
-				instanceFields["t"] = new Serializee("cba");
-				instanceFields["or"] = new Serializee(fv.ToString());
 			}
 			else if( fv is UnityEngine.Object )
 			{
-				instanceFields["fo"] = new Serializee(fieldsObjects.Count.ToString());
+				spf.fieldType = (byte)ProxyFieldType.ObjectRef;
+				spf.fieldObjectIndex = fieldsObjects.Count;
+				spf.objectRefName = fv.ToString();
+				spf.objectRefIsNull = spf.objectRefName == "null";
 				fieldsObjects.Add( (UnityEngine.Object)fv );
-				instanceFields["t"] = new Serializee("obj");
-				instanceFields["or"] = new Serializee(fv.ToString());
 			}
 			else if( fv is string )
 			{
-				instanceFields["d"] = new Serializee(fv.ToString());
-				instanceFields["t"] = new Serializee("s");
+				spf.fieldType = (byte)ProxyFieldType.String;
+				spf.data = fv.ToString();
 			}
 			else if( StackElement.TypeToStackType.TryGetValue( fvType.ToString(), out st ) && st < StackType.Object )
 			{
-				instanceFields["d"] = new Serializee(fv.ToString());
-				instanceFields["t"] = new Serializee("e" + st);
+				spf.fieldType = (byte)ProxyFieldType.Primitive;
+				spf.primitiveValue.Unbox( fv, st );
 			}
 			else if( fvType.IsArray )
 			{
-				instanceFields["t"] = new Serializee( "a" );
-				instanceFields["at"] = SerializedTypeDescriptorBuilder.FromNativeType(fvType.GetElementType()).ToSerializee();
+				spf.fieldType = (byte)ProxyFieldType.Array;
+				Type type = fvType.GetElementType();
+				spf.elementType = SerializedTypeDescriptorBuilder.FromNativeType( type );
 				Array arr = (Array)fv;
 				int len = arr.Length;
-				instanceFields["al"] = new Serializee( len.ToString() );
-
-				Serializee [] sel = new Serializee[len];
-				int i;
-				for( i = 0; i < len; i++ )
+				spf.arrayElements = new SerializedProxyField[len];
+				for( int i = 0; i < len; i++ )
 				{
 					object o = arr.GetValue(i);
-					sel[i] = SerializeThing( o, null, -1, ref refToProxyMap );
+					spf.arrayElements[i] = SerializeProxyField( o, null, -1, ref refToProxyMap );
 				}
-				instanceFields["ad"] = new Serializee( sel );
 			}
 			else
 			{
-				string json = JsonUtility.ToJson(fv);
-				instanceFields["t"] = new Serializee( "j" );
-				instanceFields["d"] = new Serializee(json);
-				instanceFields["at"] = SerializedTypeDescriptorBuilder.FromNativeType(fvType).ToSerializee();
+				spf.fieldType = (byte)ProxyFieldType.Json;
+				spf.data = JsonUtility.ToJson(fv);
+				spf.elementType = SerializedTypeDescriptorBuilder.FromNativeType( fvType );
 			}
 
-
-			return new Serializee(instanceFields);
+			return spf;
 		}
 
 #endif
@@ -274,23 +257,17 @@ namespace Cilbox
 				int fieldCount = cls.instanceFieldNames.Length;
 				fields = new StackElement[fieldCount];
 
-				Serializee [] d = new Serializee( Convert.FromBase64String( serializedObjectData ), Serializee.ElementType.Map ).AsArray();
+				SerializedProxy proxyData = SerializedProxy.DeserializeString( serializedObjectData );
 
-				Serializee [] matchingSerializeeInstanceField = new Serializee[fieldCount];
-				Dictionary< String, Serializee > [] matchingDicts = new Dictionary< String, Serializee >[fieldCount];
-				foreach( Serializee s in d )
+				SerializedProxyField[] matchingProxyField = new SerializedProxyField[fieldCount];
+				foreach( SerializedProxyField spf in proxyData.fields )
 				{
 					// Go over the root objects, to see which ones slot in and how.
-					// Cache the parsed dict so the load pass below doesn't reparse.
-					Dictionary< String, Serializee > dict = s.AsMap();
-					if( dict.ContainsKey( "t" ) && dict.TryGetValue( "miid", out Serializee miid ) )
+					if( (ProxyFieldType)spf.fieldType != ProxyFieldType.Empty &&
+						spf.matchingInstanceId >= 0 &&
+						spf.matchingInstanceId < matchingProxyField.Length )
 					{
-						if( UInt32.TryParse( miid.AsString(), out UInt32 nMIID ) &&
-							nMIID < fieldCount )
-						{
-							matchingSerializeeInstanceField[nMIID] = s;
-							matchingDicts[nMIID] = dict;
-						}
+						matchingProxyField[spf.matchingInstanceId] = spf;
 					}
 				}
 
@@ -328,6 +305,13 @@ namespace Cilbox
 							Debug.LogWarning( $"[CilboxProxy:{gameObject.name}] Failed to create default value for {cls.instanceFieldNames[i]} ({fieldType}): {e.Message}" );
 						}
 					}
+					else if( fieldType == typeof(string) )
+					{
+						// Empty/unset string fields default to string.Empty (matches Unity), not null.
+						fields[i].LoadObject( string.Empty );
+						if (verboseLogging)
+							ProxyDebugLog( $"Default field init {cls.instanceFieldNames[i]} <- string.Empty" );
+					}
 					else
 					{
 						fields[i].LoadObject( null );
@@ -342,12 +326,17 @@ namespace Cilbox
 				// load serialized fields.
 				for( int i = 0; i < fieldCount; i++ )
 				{
-					Serializee s = matchingSerializeeInstanceField[i];
+					SerializedProxyField spf = matchingProxyField[i];
 
-					if( s == null ) { /* Debug.Log( $"Skipping {i} {cls.instanceFieldNames[i]}" ); */ continue; }
+					if( spf == null ) { /* Debug.Log( $"Skipping {i} {cls.instanceFieldNames[i]}" ); */ continue; }
 
-					object o;
-					bool bIsObject = LoadObjectFromSerializee( s, out o, cls.instanceFieldNames[i], cls.instanceFieldTypes[i], true, matchingDicts[i] );
+					if( (ProxyFieldType)spf.fieldType == ProxyFieldType.Primitive )
+					{
+						spf.primitiveValue.ToStackElement(ref fields[i]);
+						continue;
+					}
+
+					bool bIsObject = LoadObjectFromProxyField( spf, out object o, cls.instanceFieldNames[i] );
 					if( bIsObject )
 						fields[i].LoadObject( o );
 					else
@@ -369,145 +358,158 @@ namespace Cilbox
 
 
 		// Returns: true if is object, otherwise is primitive.
-		// `dict` may be supplied by callers that already parsed the Serializee to avoid a redundant AsMap allocation.
-		private bool LoadObjectFromSerializee( Serializee s, out object oOut, String rootFieldName, Type inType, bool root, Dictionary< String, Serializee > dict = null )
+		private bool LoadObjectFromProxyField( SerializedProxyField spf, out object oOut, String rootFieldName )
 		{
+			ProxyFieldType ft = (ProxyFieldType)spf.fieldType;
 			List<UnityEngine.Object> objectSlots = runtimeFieldsObjects ?? fieldsObjects;
-			if( dict == null ) dict = s.AsMap();
 
-			Serializee setype;
-			if( dict.TryGetValue( "t", out setype ) )
+			switch (ft)
 			{
-				String sT = setype.AsString();
-				if( sT == "cba" || sT == "obj" )
+			case ProxyFieldType.CilboxRef:
+			case ProxyFieldType.ObjectRef:
+			{
+				int iFO = spf.fieldObjectIndex;
+				if (iFO < 0 || iFO >= objectSlots.Count) // break early if index is out of bounds
 				{
-					Serializee seFO;
-					int iFO;
-					if( dict.TryGetValue( "fo", out seFO ) &&
-						Int32.TryParse( seFO.AsString(), out iFO ) &&
-						objectSlots != null &&
-						iFO >= 0 &&
-						iFO < objectSlots.Count )
-					{
-						if (dict.TryGetValue("or", out var seOr))
-						{
-							if (seOr.AsString() == "null")
-							{
-								// This field was null when serialized, so just return null
-								oOut = null;
-								return true;
-							}
-						}
-
-						UnityEngine.Object o = objectSlots[iFO];
-
-						//Debug.Log( $"LOADING FIELD: {i} with {o}" );
-						if( o )
-						{
-							if( o is CilboxProxy )
-								((CilboxProxy)o).RuntimeProxyLoad();
-
-							oOut = o;
-
-							// Remove reference out of the fieldsObjects array.
-							objectSlots[iFO] = null;
-
-							return true;
-						}
-						Debug.LogWarning( $"[CilboxProxy:{gameObject.name}] Object reference slot {iFO} for field {rootFieldName} is null/missing at load time." );
-					}
-					else
-					{
-						int objectSlotCount = objectSlots != null ? objectSlots.Count : 0;
-						Debug.LogWarning( $"Failure to load object in field id:{rootFieldName} of {className} (slot parse failed or out of range, fieldsObjects count={objectSlotCount})");
-					}
+					Debug.LogWarning(
+						$"Failure to load object in field id:{rootFieldName} of {className} (slot out of range, fieldsObjects count={objectSlots.Count})");
+					break;
 				}
-				else if( sT[0] == 'a' )
+
+				if (spf.objectRefIsNull)
 				{
-					Serializee seT, seAT, seAL, seAD;
-					int aLen;
-					if( dict.TryGetValue( "t", out seT ) &&
-						dict.TryGetValue( "at", out seAT ) &&
-						dict.TryGetValue( "al", out seAL ) &&
-						dict.TryGetValue( "ad", out seAD ) &&
-						Int32.TryParse( seAL.AsString(), out aLen ) )
-					{
-						SerializedTypeDescriptor tdAT = SerializedTypeDescriptor.FromSerializee( seAT );
-						Type t = box.usage.GetNativeTypeFromDescriptor(tdAT);
-						bool isCilboxElementType = false;
-
-						if (t == null)
-						{
-							// Check the array to see if it is Cilboxed
-							Dictionary<String, Serializee> atMap = seAT.AsMap();
-							String elementTypeName = atMap["n"].AsString();
-							if (box.classes.ContainsKey(elementTypeName))
-							{
-								t = typeof(CilboxProxy);
-								isCilboxElementType = true;
-							}
-							else
-							{
-								oOut = null;
-								return true;
-							}
-						}
-
-						if( !isCilboxElementType && !box.CheckTypeAllowed( t.ToString() ) )
-						{
-							proxyWasSetup = false;
-							throw new Exception( "Contraband ARRAY found in script {className} { cls.instanceFieldNames[i] }" );
-						}
-
-						Array arr = Array.CreateInstance( t, aLen );
-
-						// Hoist AsArray out of the loop — it previously re-parsed seAD and allocated
-						// a fresh Serializee[] of size aLen on every iteration (O(aLen^2) GC).
-						Serializee [] adArr = seAD.AsArray();
-						for( int j = 0; j < aLen; j++ )
-						{
-							object o;
-							LoadObjectFromSerializee( adArr[j], out o, rootFieldName, t, false );
-							arr.SetValue( o, j );
-						}
-
-						oOut = arr;
-						return true;
-					}
+					// This field was null when serialized, so just return null
+					oOut = null;
+					return true;
 				}
-				else if( sT[0] == 's' || sT[0] == 'e' )
+
+				UnityEngine.Object o = objectSlots[iFO];
+
+				if (o)
 				{
-					Serializee dsee;
-					if( dict.TryGetValue( "d", out dsee ) )
-					{
-						oOut = CilboxUtil.DeserializeDataForProxyField( inType, dsee.AsString() );
-						return false;
-					}
-				}
-				else if ( sT[0] == 'j' )
-				{
+					if (o is CilboxProxy cilboxProxy)
+						cilboxProxy.RuntimeProxyLoad();
 
-					Serializee seT, seAT, seD;
-					if( dict.TryGetValue( "t", out seT ) &&
-						dict.TryGetValue( "at", out seAT ) &&
-						dict.TryGetValue( "d", out seD ) )
-					{
-						SerializedTypeDescriptor tdAT = SerializedTypeDescriptor.FromSerializee( seAT );
-						Type t = box.usage.GetNativeTypeFromDescriptor(tdAT); // This makes sure we're allowed to have this type.
-						oOut = JsonUtility.FromJson(seD.AsString(), t);
-						return true;
-					}
-					else
-					{
-						Debug.LogWarning( $"Failure to load object in field id:{rootFieldName} of {className}");
-					}
+					oOut = o;
+
+					// Remove reference out of the fieldsObjects array.
+					objectSlots[iFO] = null;
+
+					return true;
 				}
-				else
-				{
-					Debug.LogWarning( $"Unknown field type {sT} on field {rootFieldName}" );
-				}
+
+				Debug.LogWarning(
+					$"[CilboxProxy:{gameObject.name}] Object reference slot {iFO} for field {rootFieldName} is null/missing at load time.");
+
+				break;
 			}
-			//Debug.Log( $"{i} Output Type:{fields[i].type} Name:{cls.instanceFieldNames[i]} C# field Name:{cls.instanceFieldTypes[i]} Type:{fields[i].type} Value:{((fields[i].type<StackType.Object)?(fields[i].i):(fields[i].o))}" );
+
+			case ProxyFieldType.Array:
+			{
+				Type t = box.usage.GetNativeTypeFromDescriptor( spf.elementType );
+				bool isCilboxElementType = false;
+
+				if (t == null)
+				{
+					if (box.classes.ContainsKey(spf.elementType.typeName))
+					{
+						// Check the array to see if it is Cilboxed
+						t = typeof(CilboxProxy);
+						isCilboxElementType = true;
+					}
+					else // type is null and not a Cilbox class
+					{
+						oOut = null;
+						return true;
+					}
+				}
+
+				if( !isCilboxElementType && !box.CheckTypeAllowed( t.ToString() ) )
+				{
+					proxyWasSetup = false;
+					throw new Exception( $"Contraband ARRAY found in script {className} field {rootFieldName}" );
+				}
+
+				int aLen = spf.arrayElements.Length;
+				Array arr = Array.CreateInstance( t, aLen );
+
+				StackType elementSt = default;
+				bool isPrimArr = !isCilboxElementType
+					&& StackElement.TypeToStackType.TryGetValue(t.ToString(), out elementSt)
+					&& elementSt < StackType.Object;
+
+				if( isPrimArr )
+				{
+					// Typed array fill — one cast outside the loop, direct typed writes inside. Zero boxes.
+					switch( elementSt )
+					{
+					case StackType.Boolean: { var a = (bool[])  arr; for (int j = 0; j < aLen; j++) a[j] =         spf.arrayElements[j].primitiveValue.b; break; }
+					case StackType.Sbyte:   { var a = (sbyte[]) arr; for (int j = 0; j < aLen; j++) a[j] = (sbyte) spf.arrayElements[j].primitiveValue.l; break; }
+					case StackType.Byte:    { var a = (byte[])  arr; for (int j = 0; j < aLen; j++) a[j] = (byte)  spf.arrayElements[j].primitiveValue.e; break; }
+					case StackType.Short:   { var a = (short[]) arr; for (int j = 0; j < aLen; j++) a[j] = (short) spf.arrayElements[j].primitiveValue.l; break; }
+					case StackType.Ushort:  { var a = (ushort[])arr; for (int j = 0; j < aLen; j++) a[j] = (ushort)spf.arrayElements[j].primitiveValue.e; break; }
+					case StackType.Int:     { var a = (int[])   arr; for (int j = 0; j < aLen; j++) a[j] = (int)   spf.arrayElements[j].primitiveValue.l; break; }
+					case StackType.Uint:    { var a = (uint[])  arr; for (int j = 0; j < aLen; j++) a[j] = (uint)  spf.arrayElements[j].primitiveValue.e; break; }
+					case StackType.Long:    { var a = (long[])  arr; for (int j = 0; j < aLen; j++) a[j] =         spf.arrayElements[j].primitiveValue.l; break; }
+					case StackType.Ulong:   { var a = (ulong[]) arr; for (int j = 0; j < aLen; j++) a[j] =         spf.arrayElements[j].primitiveValue.e; break; }
+					case StackType.Float:   { var a = (float[]) arr; for (int j = 0; j < aLen; j++) a[j] =         spf.arrayElements[j].primitiveValue.f; break; }
+					case StackType.Double:  { var a = (double[])arr; for (int j = 0; j < aLen; j++) a[j] =         spf.arrayElements[j].primitiveValue.d; break; }
+					}
+				}
+				else // non-primitive array
+				{
+					for( int j = 0; j < aLen; j++ )
+					{
+						LoadObjectFromProxyField( spf.arrayElements[j], out object o, rootFieldName );
+						arr.SetValue( o, j );
+					}
+				}
+
+				oOut = arr;
+				return true;
+			}
+
+			case ProxyFieldType.String:
+			{
+				oOut = spf.data;
+				return false;
+			}
+
+			case ProxyFieldType.Primitive:
+			{
+				// Slow path — only reached if a caller didn't short-circuit. Re-boxes from the
+				// 16-byte PrimitivePayload (no object slot, so the StackElement.AsObject branches
+				// for Address/NativeHandle/Object don't apply here).
+				oOut = spf.primitiveValue.type switch
+				{
+					StackType.Boolean => spf.primitiveValue.b,
+					StackType.Sbyte => (sbyte)spf.primitiveValue.l,
+					StackType.Byte => (byte)spf.primitiveValue.e,
+					StackType.Short => (short)spf.primitiveValue.l,
+					StackType.Ushort => (ushort)spf.primitiveValue.e,
+					StackType.Int => (int)spf.primitiveValue.l,
+					StackType.Uint => (uint)spf.primitiveValue.e,
+					StackType.Long => spf.primitiveValue.l,
+					StackType.Ulong => spf.primitiveValue.e,
+					StackType.Float => spf.primitiveValue.f,
+					StackType.Double => spf.primitiveValue.d,
+					_ => throw new NotSupportedException($"PrimitivePayload cannot box StackType {spf.primitiveValue.type}")
+				};
+				return false;
+			}
+
+			case ProxyFieldType.Json:
+			{
+				Type t = box.usage.GetNativeTypeFromDescriptor( spf.elementType );
+				oOut = JsonUtility.FromJson(spf.data, t);
+				return true;
+			}
+
+			case ProxyFieldType.Empty:
+			default:
+				break;
+			}
+
 			oOut = null;
 			return false;
 		}

--- a/Packages/com.cnlohr.cilbox/CilboxSerialization.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxSerialization.cs
@@ -643,4 +643,261 @@ namespace Cilbox
 			return td;
 		}
 	}
+
+	public enum ProxyFieldType : byte
+	{
+		Empty       = 0,  // null field
+		String      = 1,  // "s"
+		Primitive   = 2,  // "e<StackType>" — primitives and enums
+		CilboxRef   = 3,  // "cba" — Cilboxable object reference
+		ObjectRef   = 4,  // "obj" — UnityEngine.Object reference
+		Array       = 5,  // "a"
+		Json        = 6,  // "j" — JsonUtility-serialized struct
+	}
+
+	// Primitive-only value payload. 16 bytes (no object slot). NOTE: keep the
+	// value-slot field offsets in lockstep with StackElement (offset 8, same
+	// union layout) - the consume site copies the 8-byte `l` slot directly into
+	// StackElement.l, relying on identical bit layout for b/f/d/l/e.
+	[StructLayout(LayoutKind.Explicit)]
+	public struct PrimitivePayload
+	{
+		[FieldOffset(0)] public StackType type;
+		[FieldOffset(8)] public bool   b;
+		[FieldOffset(8)] public float  f;
+		[FieldOffset(8)] public double d;
+		[FieldOffset(8)] public long   l;
+		[FieldOffset(8)] public ulong  e;
+
+		public void Unbox( object i, StackType st )
+		{
+			type = st;
+			switch( st )
+			{
+				case StackType.Boolean: this.l = ((bool)i)?1:0; break;
+				case StackType.Sbyte:   this.l = (sbyte)i;      break;
+				case StackType.Byte:    this.e = (byte)i;       break;
+				case StackType.Short:   this.l = (short)i;      break;
+				case StackType.Ushort:  this.e = (ushort)i;     break;
+				case StackType.Int:     this.l = (int)i;        break;
+				case StackType.Uint:    this.e = (uint)i;       break;
+				case StackType.Long:    this.l = (long)i;       break;
+				case StackType.Ulong:   this.e = (ulong)i;      break;
+				case StackType.Float:   this.l = 0; this.f = (float)i;  break;
+				case StackType.Double:  this.d = (double)i;     break;
+			}
+		}
+
+		public void ToStackElement(ref StackElement se)
+		{
+			se.type = type;
+			se.l = l; // copy full 8 bytes
+			se.o = null; // clear if previously set
+		}
+	}
+
+	public class SerializedProxyField
+	{
+		public byte fieldType;            // ProxyFieldType
+		public string fieldName;          // null for non-root (array elements)
+		public int matchingInstanceId;    // -1 for non-root
+
+		// String / Json
+		public string data;               // value as string / JSON text
+		// Primitive
+		public PrimitivePayload primitiveValue;  // primitiveValue.type holds the StackType
+
+		// CilboxRef / ObjectRef
+		public int fieldObjectIndex;      // index into fieldsObjects
+		public bool objectRefIsNull;      // true when the original ref was null
+		public string objectRefName;      // fv.ToString() of the referenced object
+
+		// Array / Json
+		public SerializedTypeDescriptor elementType;
+
+		// Array (recursive)
+		public SerializedProxyField[] arrayElements;
+
+		private static String PrimitiveToString( in PrimitivePayload v )
+		{
+			switch( v.type )
+			{
+				case StackType.Boolean: return v.b.ToString();
+				case StackType.Sbyte:   return ((sbyte)v.l).ToString();
+				case StackType.Byte:    return ((byte)v.e).ToString();
+				case StackType.Short:   return ((short)v.l).ToString();
+				case StackType.Ushort:  return ((ushort)v.e).ToString();
+				case StackType.Int:     return ((int)v.l).ToString();
+				case StackType.Uint:    return ((uint)v.e).ToString();
+				case StackType.Long:    return v.l.ToString();
+				case StackType.Ulong:   return v.e.ToString();
+				case StackType.Float:   return v.f.ToString();
+				case StackType.Double:  return v.d.ToString();
+				default: throw new CilboxException( $"Unknown primitive StackType {v.type}" );
+			}
+		}
+
+		private static PrimitivePayload PrimitiveFromString( String d, StackType st )
+		{
+			PrimitivePayload v = default;
+			v.type = st;
+			switch( st )
+			{
+				case StackType.Boolean: v.l = bool.Parse( d ) ? 1 : 0; break;
+				case StackType.Sbyte:   v.l = sbyte.Parse( d );        break;
+				case StackType.Byte:    v.e = byte.Parse( d );         break;
+				case StackType.Short:   v.l = short.Parse( d );        break;
+				case StackType.Ushort:  v.e = ushort.Parse( d );       break;
+				case StackType.Int:     v.l = int.Parse( d );          break;
+				case StackType.Uint:    v.e = uint.Parse( d );         break;
+				case StackType.Long:    v.l = long.Parse( d );         break;
+				case StackType.Ulong:   v.e = ulong.Parse( d );        break;
+				case StackType.Float:   v.l = 0; v.f = float.Parse( d ); break;
+				case StackType.Double:  v.d = double.Parse( d );       break;
+				default: throw new CilboxException( $"Unknown primitive StackType {st}" );
+			}
+			return v;
+		}
+
+		// Mirrors CilboxProxy.SerializeThing. Empty fields emit ONLY {empty:"true"}.
+		// Otherwise: [n], [miid], then type-specific keys in master's exact order.
+		public Serializee ToSerializee()
+		{
+			Dictionary<String, Serializee> f = new Dictionary<String, Serializee>();
+
+			if( (ProxyFieldType)fieldType == ProxyFieldType.Empty )
+			{
+				f["empty"] = new Serializee( "true" );
+				return new Serializee( f );
+			}
+
+			if( fieldName != null )
+				f["n"] = new Serializee( fieldName );
+			if( matchingInstanceId >= 0 )
+				f["miid"] = new Serializee( matchingInstanceId.ToString() );
+
+			switch( (ProxyFieldType)fieldType )
+			{
+				case ProxyFieldType.String:
+					f["d"] = new Serializee( data );
+					f["t"] = new Serializee( "s" );
+					break;
+				case ProxyFieldType.Primitive:
+					f["d"] = new Serializee( PrimitiveToString( primitiveValue ) );
+					f["t"] = new Serializee( "e" + primitiveValue.type );
+					break;
+				case ProxyFieldType.CilboxRef:
+					f["fo"] = new Serializee( fieldObjectIndex.ToString() );
+					f["t"] = new Serializee( "cba" );
+					f["or"] = new Serializee( objectRefName );
+					break;
+				case ProxyFieldType.ObjectRef:
+					f["fo"] = new Serializee( fieldObjectIndex.ToString() );
+					f["t"] = new Serializee( "obj" );
+					f["or"] = new Serializee( objectRefName );
+					break;
+				case ProxyFieldType.Array:
+					f["t"] = new Serializee( "a" );
+					f["at"] = elementType.ToSerializee();
+					f["al"] = new Serializee( arrayElements.Length.ToString() );
+					Serializee[] ad = new Serializee[arrayElements.Length];
+					for( int i = 0; i < arrayElements.Length; i++ )
+						ad[i] = arrayElements[i].ToSerializee();
+					f["ad"] = new Serializee( ad );
+					break;
+				case ProxyFieldType.Json:
+					f["t"] = new Serializee( "j" );
+					f["d"] = new Serializee( data );
+					f["at"] = elementType.ToSerializee();
+					break;
+			}
+			return new Serializee( f );
+		}
+
+		public static SerializedProxyField FromSerializee( Serializee s )
+		{
+			Dictionary<String, Serializee> m = s.AsMap();
+			SerializedProxyField f = new SerializedProxyField();
+			f.matchingInstanceId = -1;
+
+			if( m.ContainsKey( "empty" ) )
+			{
+				f.fieldType = (byte)ProxyFieldType.Empty;
+				return f;
+			}
+
+			if( m.TryGetValue( "n", out Serializee nS ) )
+				f.fieldName = nS.AsString();
+			if( m.TryGetValue( "miid", out Serializee miidS ) )
+				f.matchingInstanceId = Int32.Parse( miidS.AsString() );
+
+			String t = m["t"].AsString();
+			if( t == "s" )
+			{
+				f.fieldType = (byte)ProxyFieldType.String;
+				f.data = m["d"].AsString();
+			}
+			else if( t == "cba" )
+			{
+				f.fieldType = (byte)ProxyFieldType.CilboxRef;
+				f.fieldObjectIndex = Int32.Parse( m["fo"].AsString() );
+				f.objectRefName = m["or"].AsString();
+				f.objectRefIsNull = f.objectRefName == "null";
+			}
+			else if( t == "obj" )
+			{
+				f.fieldType = (byte)ProxyFieldType.ObjectRef;
+				f.fieldObjectIndex = Int32.Parse( m["fo"].AsString() );
+				f.objectRefName = m["or"].AsString();
+				f.objectRefIsNull = f.objectRefName == "null";
+			}
+			else if( t == "a" )
+			{
+				f.fieldType = (byte)ProxyFieldType.Array;
+				f.elementType = SerializedTypeDescriptor.FromSerializee( m["at"] );
+				Serializee[] ad = m["ad"].AsArray();
+				f.arrayElements = new SerializedProxyField[ad.Length];
+				for( int i = 0; i < ad.Length; i++ )
+					f.arrayElements[i] = FromSerializee( ad[i] );
+			}
+			else if( t == "j" )
+			{
+				f.fieldType = (byte)ProxyFieldType.Json;
+				f.data = m["d"].AsString();
+				f.elementType = SerializedTypeDescriptor.FromSerializee( m["at"] );
+			}
+			else if( t.Length > 0 && t[0] == 'e' )
+			{
+				f.fieldType = (byte)ProxyFieldType.Primitive;
+				StackType st = (StackType)Enum.Parse( typeof(StackType), t.Substring(1) );
+				f.primitiveValue = PrimitiveFromString( m["d"].AsString(), st );
+			}
+			return f;
+		}
+	}
+
+	public class SerializedProxy
+	{
+		public SerializedProxyField[] fields;
+
+		// Root is a List of per-field Maps, base64-encoded — identical to
+		// master's serializedObjectData.
+		public string SerializeString()
+		{
+			Serializee[] arr = new Serializee[fields.Length];
+			for( int i = 0; i < fields.Length; i++ )
+				arr[i] = fields[i].ToSerializee();
+			return Convert.ToBase64String( new Serializee( arr ).DumpAsMemory().ToArray() );
+		}
+
+		public static SerializedProxy DeserializeString( string base64 )
+		{
+			SerializedProxy p = new SerializedProxy();
+			Serializee[] arr = new Serializee( Convert.FromBase64String( base64 ), Serializee.ElementType.Map ).AsArray();
+			p.fields = new SerializedProxyField[arr.Length];
+			for( int i = 0; i < arr.Length; i++ )
+				p.fields[i] = SerializedProxyField.FromSerializee( arr[i] );
+			return p;
+		}
+	}
 }

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -952,13 +952,14 @@ namespace TestCilbox
 			Cilbox.CilboxProxy proxy = new Cilbox.CilboxProxy();
 			proxy.fieldsObjects = new List<UnityEngine.Object>();
 
-			Dictionary<string, Serializee> dict = new Dictionary<string, Serializee>();
-			dict["t"] = new Serializee("obj");
-			dict["fo"] = new Serializee("-1");
-			Serializee serialized = new Serializee(dict);
+			SerializedProxyField spf  = new SerializedProxyField
+			{
+				fieldType = (byte)ProxyFieldType.ObjectRef,
+				fieldObjectIndex = -1,
+			};
 
 			MethodInfo method = typeof(Cilbox.CilboxProxy).GetMethod(
-				"LoadObjectFromSerializee",
+				"LoadObjectFromProxyField",
 				BindingFlags.Instance | BindingFlags.NonPublic);
 			if( method == null )
 			{
@@ -968,7 +969,7 @@ namespace TestCilbox
 
 			try
 			{
-				object[] args = new object[] { serialized, null, "badField", typeof(UnityEngine.Object), true, null };
+				object[] args = new object[] { spf, null, "badField" };
 				object result = method.Invoke(proxy, args);
 				bool loaded = result is bool b && b;
 				Validator.Set("Negative fieldsObjects index", loaded ? "loaded" : "ignored");

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -959,7 +959,7 @@ namespace TestCilbox
 			};
 
 			MethodInfo method = typeof(Cilbox.CilboxProxy).GetMethod(
-				"LoadObjectFromProxyField",
+				"LoadProxyFieldStackElement",
 				BindingFlags.Instance | BindingFlags.NonPublic);
 			if( method == null )
 			{
@@ -969,7 +969,8 @@ namespace TestCilbox
 
 			try
 			{
-				object[] args = new object[] { spf, null, "badField" };
+				StackElement refElement = default;
+				object[] args = new object[] { spf, refElement, "badField" };
 				object result = method.Invoke(proxy, args);
 				bool loaded = result is bool b && b;
 				Validator.Set("Negative fieldsObjects index", loaded ? "loaded" : "ignored");


### PR DESCRIPTION
Implement `SerializedProxy`, `SerializedProxyField`, and `PrimitivePayload` structs
* Uses Serializee under the hood; wire format is the same

The changes in CilboxProxy and design of the primitive serialization are intended to minimize allocations on load, but it gets a little funky. Let me know if you'd like to take a different path here,

After this PR, there will be no references to `Serializee` outside of `CilboxSerialization` and where it is defined in `CilboxUtil`.
