### PR TITLE
slightly reduce reflection in class load and runtime

### DIFF
--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -2052,7 +2052,7 @@ spiperf.End();
 		private static readonly string[] importFunctionNames = BuildImportFunctionNames();
 		private static string[] BuildImportFunctionNames()
 		{
-			string[] names = Enum.GetNames<ImportFunctionID>();
+			string[] names = Enum.GetNames(typeof(ImportFunctionID));
 			names[0] = ".ctor";
 			return names;
 		}

--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -1418,8 +1418,8 @@ spiperf.Begin();
 						case 6: // ldelem.i8: the only variant without an unsigned counterpart, emitted for
 							// long[] and ulong[] alike.  A (ulong[]) cast also succeeds on a long[], so
 							// only here the element type must decide the signedness of the stack type.
-							if( Type.GetTypeCode( arr.GetType().GetElementType() ) == TypeCode.UInt64 )
-								stackBuffer[sp].LoadUlong( ((ulong[])arr)[index] );
+							if( arr is ulong[] ulongArr )
+								stackBuffer[sp].LoadUlong( ulongArr[index] );
 							else
 								stackBuffer[sp].LoadLong( ((long[])arr)[index] );
 							break;
@@ -1514,8 +1514,8 @@ spiperf.Begin();
 							break;
 						case 4: // stelem.i8 (used for Int64/UInt64 element arrays; SetValue can't
 							// put a boxed long into a ulong[], so store through the array cast)
-							if( Type.GetTypeCode( asArr.GetType().GetElementType() ) == TypeCode.UInt64 )
-								((ulong[])asArr)[index] = valSE.e;
+							if( asArr is ulong[] ulongArr )
+								ulongArr[index] = valSE.e;
 							else
 								((long[])asArr)[index] = valSE.l;
 							break;
@@ -2047,6 +2047,16 @@ spiperf.End();
 
 		public String [] baseClassNames = new String[0];
 
+		// cache importFunctionNames because they won't change between Cilbox loads; avoids
+		// reflection lookups on every class load.
+		private static readonly string[] importFunctionNames = BuildImportFunctionNames();
+		private static string[] BuildImportFunctionNames()
+		{
+			string[] names = Enum.GetNames<ImportFunctionID>();
+			names[0] = ".ctor";
+			return names;
+		}
+
 		public bool LoadCilboxClass( Cilbox box, SerializedClass sc )
 		{
 			this.box = box;
@@ -2087,18 +2097,11 @@ spiperf.End();
 
 			// These imports are for things like Start(), Update(), Awake(), etc...
 			// so that we can call back into the class.
-			int numImportFunctions = Enum.GetNames(typeof(ImportFunctionID)).Length;
+			int numImportFunctions = importFunctionNames.Length;
 			importFunctionToId = new uint[numImportFunctions];
 			for( int i = 0; i < numImportFunctions; i++ )
 			{
-				String fn = Enum.GetName(typeof(ImportFunctionID), i);
-				if( i == 0 ) fn = ".ctor";
-				uint idx = 0;
-				importFunctionToId[i] = 0xffffffff;
-				if( methodNameToIndex.TryGetValue(fn, out idx ) )
-				{
-					importFunctionToId[i] = idx;
-				}
+				importFunctionToId[i] = methodNameToIndex.GetValueOrDefault(importFunctionNames[i], 0xffffffff);
 			}
 
 			return true;

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -793,6 +793,11 @@ namespace TestCilbox
 			Validator.Validate("Ulong Array Assigned 0", ulong.MaxValue.ToString());
 			Validator.Validate("Ulong Array Assigned 1", "42");
 
+			Validator.Validate("Long Array Assigned Length", "3");
+			Validator.Validate("Long Array Assigned 0", "-1");
+			Validator.Validate("Long Array Assigned 1", "9876543210");
+			Validator.Validate("Long Array Assigned 2", long.MinValue.ToString());
+
 			Validator.Validate("Char Array With Data Length", "3");
 			Validator.Validate("Char Array With Data 0", "a");
 			Validator.Validate("Char Array With Data 1", "4660");

--- a/TestCilbox/TestCilboxable.cs
+++ b/TestCilbox/TestCilboxable.cs
@@ -572,6 +572,15 @@ namespace TestCilbox
 			Validator.Set("Ulong Array Assigned 0", ulongAssigned[0].ToString() );
 			Validator.Set("Ulong Array Assigned 1", ulongAssigned[1].ToString() );
 
+			long[] longAssigned = new long[3];
+			longAssigned[0] = -1L;
+			longAssigned[1] = 9876543210L;
+			longAssigned[2] = long.MinValue;
+			Validator.Set("Long Array Assigned Length", longAssigned.Length.ToString());
+			Validator.Set("Long Array Assigned 0", longAssigned[0].ToString());
+			Validator.Set("Long Array Assigned 1", longAssigned[1].ToString());
+			Validator.Set("Long Array Assigned 2", longAssigned[2].ToString());
+
 			char[] charWithData = new char[3];
 			charWithData[0] = 'a';
 			charWithData[1] = '\u1234';


### PR DESCRIPTION
I was poking around in LoadCilboxClass for unrelated reasons and found some minor inefficiencies with reflection that I wanted to address first; I also tweaked ldelem.i8 and stelem.i8.

