### PR TITLE
Budget interpreter time per call instead of per frame

### DIFF
--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -172,20 +172,29 @@ namespace Cilbox
 			}
 
 			object ret = null;
-			if( !parentClass.box.InterpreterEntry(this) ) return null;
+			Cilbox box = parentClass.box;
+			if( !box.InterpreterEntry(this) ) return null;
 			try
 			{
 				ret = InterpretInner( stackBuffer, parameters ).AsObject();
 			}
 			catch( Exception e )
 			{
-				parentClass.box.InterpreterExit();
+				box.InterpreterExit();
+				// A timeout that surfaced inside a native callback arrives wrapped as the script's unhandled throw.
+				Exception cause = e is CilboxUnhandledInterpretedException wrapped && wrapped.Throwee is Exception inner ? inner : e;
+				if( cause is CilboxInterpreterTimeoutException timeout )
+				{
+					// Unwind to the outermost call of this entry; only that one applies the strike policy.
+					if( Cilbox.threadEntryDepth > 0 ) throw;
+					if( !box.RecordTimeout( ths, timeout ) ) return null;
+				}
 				if( ths != null ) ths.DisableProxy();
-				else parentClass.box.DisableWithReason(e.ToString());
+				else box.DisableWithReason(e.ToString());
 				if( e is CilboxUnhandledInterpretedException uhe && uhe.Throwee is System.Exception te ) throw te;
 				throw;
 			}
-			parentClass.box.InterpreterExit();
+			box.InterpreterExit();
 
 			return ret;
 		}
@@ -201,6 +210,9 @@ namespace Cilbox
 #endif
 
 			Cilbox box = parentClass.box;
+			// The deadline is fixed for the whole call tree, so read the thread-static once here
+			// rather than on every clock check.
+			long dropDead = Cilbox.threadDropDead;
 
 			int localVarsHead = MaxStackSize;
 			int stackContinues = localVarsHead + methodLocals.Length;
@@ -226,20 +238,16 @@ namespace Cilbox
 			{
 				do
 				{
-					// While this is not threadsafe, that's OK.  This is more for broad strokes.
-					// We don't have to worry about critical pieces going in/out of a race condition
-					// for instance, interpreterAccountingLastStart can't go wonky on us.
-					//
+					// The deadline is thread-local (see InterpreterEntry), so nothing here needs interlocking.
 					// If you use Interlocked.Add() it slows the whole emulator down by about 40%!
 					long steps = ++box.interpreterInstructionsCount;
 					if( ( steps & 0x3f ) == 0 )
 					{
 						long now = System.Diagnostics.Stopwatch.GetTimestamp();
-						if( now > box.interpreterAccountingDropDead )
+						if( now > dropDead )
 						{
-							box.interpreterAccountingCumulitiveTicks = now + box.timeoutLengthUs * box.interpreterTicksInUs - box.interpreterAccountingDropDead;
 							cont = false;
-							throw new CilboxInterpreterTimeoutException( "Script time resources overutilized (Timeout Us: " + box.interpreterAccountingCumulitiveTicks / box.interpreterTicksInUs + "/" + box.timeoutLengthUs + " )", parentClass.className, methodName, pc);
+							throw new CilboxInterpreterTimeoutException( "Script time resources overutilized (" + ( now - Cilbox.threadEntryStart ) / box.interpreterTicksInUs + "us in one call, limit " + box.timeoutLengthUs + "us)", parentClass.className, methodName, pc);
 						}
 					}
 
@@ -1851,6 +1859,10 @@ spiperf.End();
 
 			void interpretedThrow(int currentInstruction, object thrownObj)
 			{
+				// A timeout is never the script's to catch. One that came back through a native call
+				// (a delegate handed to Array.Sort, say) unwinds the whole entry instead.
+				for( Exception walk = thrownObj as Exception; walk != null; walk = walk.InnerException )
+					if( walk is CilboxInterpreterTimeoutException ) throw walk;
 				sp = -1;
 				exceptionRegister = new StackElement() { type = StackType.Object, o = thrownObj };
 				if (!hasExceptionClauses)
@@ -2226,13 +2238,24 @@ spiperf.End();
 
 		public virtual long MaxTimeoutLengthUs => 1000000; // 1 second. Can be overridden by specific Cilbox application.
 
-		[HideInInspector] public uint interpreterAccountingDepth = 0;
-		[HideInInspector] public long interpreterAccountingDropDead = 0;
+		// Time accounting is per thread and per top-level call: every entry from native code gets the
+		// full timeoutLengthUs, nested interpreted calls on the same thread share the outer deadline,
+		// and calls on other threads get their own. Nothing here depends on Update() running.
+		[ThreadStatic] internal static uint threadEntryDepth;
+		[ThreadStatic] internal static long threadDropDead;
+		[ThreadStatic] internal static long threadEntryStart;
 		[HideInInspector] public long interpreterAccountingCumulitiveTicks = 0;
 		[HideInInspector] public long interpreterInstructionsCount = 0;
 		[HideInInspector] public long interpreterTicksInUs = System.Diagnostics.Stopwatch.Frequency / 1000000;
+		[HideInInspector] public int timeoutStrikes = 0;
+		[HideInInspector] public long lastTimeoutTicks = 0;
 
+		// Statistics only: interpreter time spent in the previous frame, summed over all scripts in this box.
 		public long usSpentLastFrame = 0;
+		// A timeout aborts the call that overran. The script is only halted when it keeps overrunning:
+		// timeoutStrikeLimit timeouts each within timeoutStrikeWindowSeconds of the previous one.
+		public int timeoutStrikeLimit = 3;
+		public float timeoutStrikeWindowSeconds = 10f;
 
 		public Cilbox()
 		{
@@ -2536,66 +2559,68 @@ spiperf.End();
 
 		public bool InterpreterEntry( CilboxMethod m )
 		{
-			// Use of Monitor.Lock's here slows the whole emulator down by about 8%
-			// TODO: Consider some sort of lockless approach.  This is tricky because
-			// you need to make sure you interlock both depth, and, time accounting.
-			long now = System.Diagnostics.Stopwatch.GetTimestamp();
-			Monitor.Enter( this );
-			if( ++interpreterAccountingDepth == 1 )
+			// Per-thread state, so the Monitor the old accounting needed is gone, and two threads can
+			// no longer corrupt each other's depth or deadline.
+			if( threadEntryDepth == 0 )
 			{
-				// First entry, if we've been disabled, quiety abort.
-				// this is normal if
-				if( disabled )
-				{
-					--interpreterAccountingDepth;
-					Monitor.Exit( this );
-					return false;
-				}
+				// First entry, if we've been disabled, quietly abort.
+				if( disabled ) return false;
+				long now = System.Diagnostics.Stopwatch.GetTimestamp();
+				threadEntryStart = now;
+				threadDropDead = now + timeoutLengthUs * interpreterTicksInUs;
 				interpreterInstructionsCount = 0;
-				interpreterAccountingDropDead = now + timeoutLengthUs * interpreterTicksInUs - interpreterAccountingCumulitiveTicks;
-				Monitor.Exit( this );
+				threadEntryDepth = 1;
 				return true;
 			}
-			else if( disabled )
+			if( disabled )
 			{
 				// fault from within, abort now.
-				Monitor.Exit( this );
 				throw new CilboxException( $"Function interpreation happened while box was disabled. This should not be possible. Offender: {m.parentClass.className} {m.fullSignature}" );
 			}
-			else
-			{
-				if( now > interpreterAccountingDropDead )
-				{
-					interpreterAccountingCumulitiveTicks = now + timeoutLengthUs * interpreterTicksInUs - interpreterAccountingDropDead;
-					--interpreterAccountingDepth;
-					Monitor.Exit( this );
-					throw new CilboxException( $"Function {m.parentClass.className} {m.fullSignature} timed out." );
-				}
+			if( System.Diagnostics.Stopwatch.GetTimestamp() > threadDropDead )
+				throw new CilboxInterpreterTimeoutException( $"Script time resources overutilized entering {m.parentClass.className} {m.fullSignature}", m.parentClass.className, m.methodName, 0 );
 
-				// Otherwise we are recursively being called. All is well.
-				Monitor.Exit( this );
-				return true;
-			}
+			// Otherwise we are recursively being called. All is well.
+			threadEntryDepth++;
+			return true;
 		}
 
 		public void InterpreterExit()
 		{
-			Monitor.Enter( this );
-			if( --interpreterAccountingDepth == 0 )
-			{
-				long now = System.Diagnostics.Stopwatch.GetTimestamp();
-				long elapsed = now + timeoutLengthUs * interpreterTicksInUs - interpreterAccountingDropDead - interpreterAccountingCumulitiveTicks;
-				interpreterAccountingCumulitiveTicks = now + timeoutLengthUs * interpreterTicksInUs - interpreterAccountingDropDead;
+			if( --threadEntryDepth != 0 ) return;
+			long elapsed = System.Diagnostics.Stopwatch.GetTimestamp() - threadEntryStart;
+			Interlocked.Add( ref interpreterAccountingCumulitiveTicks, elapsed );
 
-				// For profiling
-				if( showFunctionProfiling )
-				{
-					Monitor.Exit( this );
-					Debug.Log( $"{interpreterInstructionsCount} in {elapsed/10}us or {interpreterInstructionsCount*10.0/(double)elapsed}MHz" );
-					return;
-				}
+			// For profiling
+			if( showFunctionProfiling )
+			{
+				long us = elapsed / interpreterTicksInUs;
+				Debug.Log( $"{interpreterInstructionsCount} in {us}us or {( us > 0 ? interpreterInstructionsCount / (double)us : 0 )}MHz" );
 			}
-			Monitor.Exit( this );
+		}
+
+		// Returns true when the script should be halted. Strikes live on the proxy (per script instance),
+		// or on the box for static entries.
+		public bool RecordTimeout( CilboxProxy ths, CilboxInterpreterTimeoutException e )
+		{
+			long now = System.Diagnostics.Stopwatch.GetTimestamp();
+			long window = (long)( timeoutStrikeWindowSeconds * System.Diagnostics.Stopwatch.Frequency );
+			int strikes;
+			if( ths != null )
+			{
+				if( now - ths.lastTimeoutTicks > window ) ths.timeoutStrikes = 0;
+				ths.lastTimeoutTicks = now;
+				strikes = ++ths.timeoutStrikes;
+			}
+			else
+			{
+				if( now - lastTimeoutTicks > window ) timeoutStrikes = 0;
+				lastTimeoutTicks = now;
+				strikes = ++timeoutStrikes;
+			}
+			bool halt = strikes >= timeoutStrikeLimit;
+			Debug.LogWarning( e.Message + ( halt ? ": halting after " + strikes + " timeouts" : ": call aborted, strike " + strikes + "/" + timeoutStrikeLimit ) );
+			return halt;
 		}
 
 		void Update()

--- a/Packages/com.cnlohr.cilbox/CilboxProxy.cs
+++ b/Packages/com.cnlohr.cilbox/CilboxProxy.cs
@@ -27,6 +27,8 @@ namespace Cilbox
 		private bool proxyLoadInProgress = false;
 
 		public bool disabled = false;
+		[System.NonSerialized] public int timeoutStrikes = 0;
+		[System.NonSerialized] public long lastTimeoutTicks = 0;
 
 		public void DisableProxy()
 		{

--- a/TestCilbox/TestCilbox.cs
+++ b/TestCilbox/TestCilbox.cs
@@ -294,6 +294,30 @@ namespace TestCilbox
 			proxy.GetType().GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic, Type.EmptyTypes).Invoke(proxy, new object[0]);
 		}
 
+		private static void InvokeProxyCallback(Cilbox.CilboxProxy proxy, string name)
+		{
+			proxy.GetType().GetMethod( name, BindingFlags.Instance|BindingFlags.NonPublic, Type.EmptyTypes ).Invoke( proxy, new object[0] );
+		}
+
+		// Runs a proxy callback and reports whether an interpreter timeout escaped to the caller.
+		private static bool InvokeProxyCallbackTimedOut(Cilbox.CilboxProxy proxy, string name)
+		{
+			try
+			{
+				InvokeProxyCallback( proxy, name );
+				return false;
+			}
+			catch( TargetInvocationException e )
+			{
+				if (e.InnerException is not CilboxInterpreterTimeoutException)
+				{
+					throw;
+				}
+				Debug.Log( e.ToString().Length.ToString() );
+				return true;
+			}
+		}
+
 		private static object GetProxyFieldObject(Cilbox.CilboxProxy proxy, string fieldName)
 		{
 			for( int i = 0; i < proxy.cls.instanceFieldNames.Length; i++ )
@@ -500,32 +524,74 @@ namespace TestCilbox
 				Validator.Validate( e.ToString(), "Should be no error." );
 			}
 
-			try
+			// RunPerfSuite below is sensitive to how much interpreted code ran before it: adding the
+			// coverage below ahead of it moved TrigUs by about 50% on this machine, which would make
+			// version-to-version perf comparisons meaningless. So while measuring, only the halt is
+			// exercised, and a strike limit of one keeps that to the single overrun it always was.
+			if( runPerf )
 			{
-				// Ensure 50ms timeout for the Update test.
+				cb.timeoutStrikeLimit = 1;
+			}
+			else
+			{
+				// The budget covers one call. Five calls that each cost a third of it must all
+				// complete; while the budget was cumulative this timed out on the third one.
+				cb.timeoutLengthUs = 60000; // 60ms, against ~20ms of work per call
+				bool partialBudgetTimedOut = false;
+				for( int i = 0; i < 5 && !partialBudgetTimedOut; i++ )
+					partialBudgetTimedOut = InvokeProxyCallbackTimedOut( proxy, "OnEnable" );
+				Validator.Set( "Partial Budget Timed Out", partialBudgetTimedOut.ToString() );
+				Validator.Validate( "Partial Budget Timed Out", "False" );
+				Validator.ValidateCount( "Partial Budget Call", 5 );
+				Validator.Set( "Proxy Alive After Partial Budget", (!proxy.disabled).ToString() );
+				Validator.Validate( "Proxy Alive After Partial Budget", "True" );
+
 				cb.timeoutLengthUs = 50000; // 50ms
-				// In case assembly is still being generated.
-				proxy.GetType().GetMethod("Update",BindingFlags.Instance|BindingFlags.NonPublic,Type.EmptyTypes).Invoke( proxy, new object[0] );
-			} catch( TargetInvocationException e )
+
+				// One overrun aborts that call and is logged, and the script stays alive, so the
+				// next callback still runs.
+				Validator.Set( "First Overtime Escaped", InvokeProxyCallbackTimedOut( proxy, "Update" ).ToString() );
+				Validator.Validate( "First Overtime Escaped", "False" );
+				Validator.Set( "Proxy Alive After One Timeout", (!proxy.disabled).ToString() );
+				Validator.Validate( "Proxy Alive After One Timeout", "True" );
+
+				Validator.Set( "Execution after timeout", "disabled" );
+				InvokeProxyCallback( proxy, "FixedUpdate" );
+				Validator.Validate( "Execution after timeout", "enabled" );
+
+				// Strikes expire: overruns spaced further apart than the window never add up.
+				cb.timeoutStrikeWindowSeconds = 0.02f;
+				InvokeProxyCallbackTimedOut( proxy, "Update" );
+				Thread.Sleep( 40 );
+				InvokeProxyCallbackTimedOut( proxy, "Update" );
+				Validator.Set( "Proxy Alive Across Strike Window", (!proxy.disabled).ToString() );
+				Validator.Validate( "Proxy Alive Across Strike Window", "True" );
+				cb.timeoutStrikeWindowSeconds = 10f;
+			}
+
+			// Ensure 50ms timeout for the Update test.
+			cb.timeoutLengthUs = 50000; // 50ms
+
+			// timeoutStrikeLimit overruns inside the window halt the script, and that one throws, so
+			// a host that wants to know about a runaway script still finds out.
+			Validator.Set( "Overtime Exception", "Not Thrown" );
+			for( int i = 0; i < cb.timeoutStrikeLimit; i++ )
 			{
-				if (e.InnerException is not CilboxInterpreterTimeoutException)
-				{
-					throw;
-				}
-				Debug.Log( e.ToString().Length.ToString() );
+				if( !InvokeProxyCallbackTimedOut( proxy, "Update" ) ) continue;
 				Validator.Set( "Overtime Exception", "Thrown" );
+				break;
 			}
 			Validator.Validate( "Overtime Exception", "Thrown" );
 			Validator.Validate( "Overtime", "timed out" );
 			Validator.Validate( "Update", "called" );
 
 			Validator.Set( "Execution after timeout", "disabled" );
-			proxy.GetType().GetMethod("FixedUpdate",BindingFlags.Instance|BindingFlags.NonPublic,Type.EmptyTypes).Invoke( proxy, new object[0] );
+			InvokeProxyCallback( proxy, "FixedUpdate" );
 			Validator.Validate( "Execution after timeout", "disabled" );
 
 			Validator.Set( "Proxy Disabled After Timeout", proxy.disabled.ToString() );
 			cb.disabled = false;
-			proxy.GetType().GetMethod("FixedUpdate",BindingFlags.Instance|BindingFlags.NonPublic,Type.EmptyTypes).Invoke( proxy, new object[0] );
+			InvokeProxyCallback( proxy, "FixedUpdate" );
 
 			cb.timeoutLengthUs = 3000000; // should be over max
 			Validator.Set("Real timeoutLengthUs", cb.timeoutLengthUs.ToString() );

--- a/TestCilbox/TestCilboxable.cs
+++ b/TestCilbox/TestCilboxable.cs
@@ -824,6 +824,20 @@ namespace TestCilbox
 			Validator.Set( "FixedUpdate", "called" );
 		}
 
+		// Costs a fraction of the budget the caller sets, so calling it repeatedly only times out
+		// if the accounting carries time from one call into the next.
+		public void OnEnable()
+		{
+			System.Diagnostics.Stopwatch sw = System.Diagnostics.Stopwatch.StartNew();
+			double result = 1.3;
+			while( sw.ElapsedMilliseconds < 20 )
+			{
+				for( int i = 0; i < 2000; i++ ) result = System.Math.Sin( result ) * 10.0;
+			}
+			Validator.AddCount( "Partial Budget Call" );
+			Validator.Set( "Partial Budget Result", result.ToString() );
+		}
+
 		public void ReadInt(ref int field)
 		{
 			int current = field;


### PR DESCRIPTION
`timeoutLengthUs` is currently a budget shared by every script in a box and refilled only by `Cilbox.Update()`. Two things follow from that.

**A box whose `Update()` does not run never refills.** Proxies initialise lazily through `RuntimeProxyLoad` -> `BoxInitialize`, so the scripts keep running while the counter only grows. In a Unity scene the exporter binds every proxy to the first non-persistent `Cilbox` it finds (`Cilbox.cs:3176`), and that can be a `CilboxPropBasis` on a prefab root which is inactive most of the time. That is how I ran into this: a world script died with `Script time resources overutilized (Timeout Us: 500006/500000)` at the closing `ret` of a method that costs tens of microseconds, hours into a session, because the budget had been draining the whole time and the 6us overshoot was just the first clock check to notice.

**Even with `Update()` running, the accounting is aggregate.** The cost of every script in a box lands on whichever script happens to be executing when the frame's budget runs out, and that script is then disabled for good on its first overrun.

Every sandbox I looked at budgets a single execution and ends only that execution:

| runtime | budget covers | on overrun |
|---|---|---|
| Roblox / Luau | one thread's run until it yields | that thread errors, the script keeps handling events |
| Node `vm` | one `runInContext` call | the call throws, the context stays usable |
| Cloudflare Workers | one request, CPU time only | that request fails |
| Redis Lua | one script call | never auto-killed; replies BUSY so an operator can `SCRIPT KILL` |
| Screeps | one tick, plus a saved bucket | that tick stops, the script runs again next tick |

The two designs that budget per frame across everything, WoW addons and UEFN Verse, are also the two that get complained about for it.

### What this changes

* `InterpreterEntry` at depth 0 sets `deadline = now + timeoutLengthUs`. Every entry from native code gets the full budget, and nested interpreted calls share the outer deadline exactly as they do today.
* Depth, deadline and entry time become `[ThreadStatic]`, so `InterpreterEntry` and `InterpreterExit` no longer take the `Monitor`, and a callback interpreted on another thread can no longer corrupt the main thread's depth or deadline.
* `interpreterAccountingCumulitiveTicks` survives only to feed `usSpentLastFrame`. Nothing enforces on it any more, so `Update()` is now statistics only.
* A timeout aborts the call that overran and logs it. `timeoutStrikeLimit` timeouts (default 3), each within `timeoutStrikeWindowSeconds` (default 10) of the one before, halt the script as before, and that one still throws so a host that wants to know about a runaway script finds out. Strikes live on the proxy, or on the box for static entries.
* `interpretedThrow` rethrows a timeout rather than offering it to script `catch` blocks. Previously a timeout raised inside a native callback, a comparison delegate handed to `Array.Sort` for instance, came back as `TargetInvocationException` and the script could swallow it.

Worth calling out for anyone depending on current behaviour: a single overrun no longer disables a script, `interpreterAccountingDepth` and `interpreterAccountingDropDead` are gone (nothing outside `Cilbox.cs` referenced them), and the timeout message now reports what this call spent instead of a running total. Defaults, the `MaxTimeoutLengthUs` clamp, the 64 instruction check interval and all serialized data are unchanged.

### Verification

`dotnet run --project TestCilbox/TestCilbox.csproj -c Release` is 360/360 green. The second commit adds coverage for the new contract: five calls that each cost a third of the budget all completing in a row (that one times out on the third call under cumulative accounting, so it is the regression test for the bug above), strike expiry across the window, and the halt after repeated overruns.

Alternating `--perf` runs put this branch and master inside each other's noise on my machine, root total roughly 325 to 370ms on both sides. One caveat found while measuring: the perf suite is sensitive to how much interpreted code ran before it. Adding the new coverage ahead of `RunPerfSuite` moved `TrigUs` by about 50%, which would quietly invalidate version to version comparisons, so the added tests are skipped under `--perf` and a strike limit of 1 keeps that run's interpreted work identical to what it was.
