### PR TITLE
Optimize interpreter stack allocations

### DIFF
--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -51,8 +51,6 @@ namespace Cilbox
 	public class CilboxMethod
 	{
 		private static readonly ArrayPool<StackElement> stackPool = ArrayPool<StackElement>.Create();
-		[ThreadStatic] private static StackElement[] singleParameterCache;
-		[ThreadStatic] private static bool singleParameterCacheInUse;
 
 		public CilboxClass parentClass;
 		public int MaxStackSize;
@@ -159,37 +157,22 @@ namespace Cilbox
 			int plen = parametersIn?.Length ?? 0;
 			int thisOffset = isStatic ? 0 : 1;
 			int parameterCount = plen + thisOffset;
-
-			bool usingSingleParameterCache = parameterCount == 1 && !singleParameterCacheInUse;
-			StackElement [] parameters;
-			if( parameterCount == 0 )
-			{
-				parameters = Array.Empty<StackElement>();
-			}
-			else if( usingSingleParameterCache )
-			{
-				parameters = singleParameterCache ?? (singleParameterCache = new StackElement[1]);
-			}
-			else
-			{
-				parameters = new StackElement[parameterCount];
-			}
-
-			StackElement [] stackBuffer = stackPool.Rent(Cilbox.defaultStackSize);
-			if( usingSingleParameterCache ) singleParameterCacheInUse = true;
+			StackElement [] paramStackArray = stackPool.Rent(parameterCount + Cilbox.defaultStackSize);
+			ArraySegment<StackElement> parameters = new (paramStackArray, 0, parameterCount);
+			ArraySegment<StackElement> stackBuffer = new (paramStackArray, parameterCount, Cilbox.defaultStackSize);
 
 			try
 			{
 				if( isStatic )
 				{
 					for( int p = 0; p < plen; p++ )
-						parameters[p].Load( parametersIn[p] );
+						paramStackArray[p].Load( parametersIn[p] );
 				}
 				else
 				{
-					parameters[0].Load( ths );
+					paramStackArray[0].Load( ths );
 					for( int p = 0; p < plen; p++ )
-						parameters[p+1].Load( parametersIn[p] );
+						paramStackArray[p+1].Load( parametersIn[p] );
 					plen++;
 				}
 
@@ -213,12 +196,7 @@ namespace Cilbox
 			}
 			finally
 			{
-				if( usingSingleParameterCache )
-				{
-					parameters[0] = default;
-					singleParameterCacheInUse = false;
-				}
-				stackPool.Return(stackBuffer, clearArray: true);
+				stackPool.Return(paramStackArray, clearArray: true);
 			}
 		}
 
@@ -477,7 +455,7 @@ spiperf.Begin();
 							object callthis = null;
 							Type[] paTypes = dt.nativeParameterTypes;
 							int numFields = paTypes.Length;
-							object [] callpar = numFields == 0 ? Array.Empty<object>() : new object[numFields];
+							object [] callpar = new object[numFields];
 							StackElement [] callpar_se = null;
 
 							int ik;

--- a/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -50,6 +50,10 @@ namespace Cilbox
 
 	public class CilboxMethod
 	{
+		private static readonly ArrayPool<StackElement> stackPool = ArrayPool<StackElement>.Create();
+		[ThreadStatic] private static StackElement[] singleParameterCache;
+		[ThreadStatic] private static bool singleParameterCacheInUse;
+
 		public CilboxClass parentClass;
 		public int MaxStackSize;
 		public String methodName;
@@ -154,40 +158,68 @@ namespace Cilbox
 
 			int plen = parametersIn?.Length ?? 0;
 			int thisOffset = isStatic ? 0 : 1;
+			int parameterCount = plen + thisOffset;
 
-			StackElement [] parameters = new StackElement[plen+thisOffset];
-			StackElement [] stackBuffer = new StackElement[Cilbox.defaultStackSize];
-
-			if( isStatic )
+			bool usingSingleParameterCache = parameterCount == 1 && !singleParameterCacheInUse;
+			StackElement [] parameters;
+			if( parameterCount == 0 )
 			{
-				for( int p = 0; p < plen; p++ )
-					parameters[p].Load( parametersIn[p] );
+				parameters = Array.Empty<StackElement>();
+			}
+			else if( usingSingleParameterCache )
+			{
+				parameters = singleParameterCache ?? (singleParameterCache = new StackElement[1]);
 			}
 			else
 			{
-				parameters[0].Load( ths );
-				for( int p = 0; p < plen; p++ )
-					parameters[p+1].Load( parametersIn[p] );
-				plen++;
+				parameters = new StackElement[parameterCount];
 			}
 
-			object ret = null;
-			if( !parentClass.box.InterpreterEntry(this) ) return null;
+			StackElement [] stackBuffer = stackPool.Rent(Cilbox.defaultStackSize);
+			if( usingSingleParameterCache ) singleParameterCacheInUse = true;
+
 			try
 			{
-				ret = InterpretInner( stackBuffer, parameters ).AsObject();
-			}
-			catch( Exception e )
-			{
-				parentClass.box.InterpreterExit();
-				if( ths != null ) ths.DisableProxy();
-				else parentClass.box.DisableWithReason(e.ToString());
-				if( e is CilboxUnhandledInterpretedException uhe && uhe.Throwee is System.Exception te ) throw te;
-				throw;
-			}
-			parentClass.box.InterpreterExit();
+				if( isStatic )
+				{
+					for( int p = 0; p < plen; p++ )
+						parameters[p].Load( parametersIn[p] );
+				}
+				else
+				{
+					parameters[0].Load( ths );
+					for( int p = 0; p < plen; p++ )
+						parameters[p+1].Load( parametersIn[p] );
+					plen++;
+				}
 
-			return ret;
+				object ret = null;
+				if( !parentClass.box.InterpreterEntry(this) ) return null;
+				try
+				{
+					ret = InterpretInner( stackBuffer, parameters ).AsObject();
+				}
+				catch( Exception e )
+				{
+					parentClass.box.InterpreterExit();
+					if( ths != null ) ths.DisableProxy();
+					else parentClass.box.DisableWithReason(e.ToString());
+					if( e is CilboxUnhandledInterpretedException uhe && uhe.Throwee is System.Exception te ) throw te;
+					throw;
+				}
+				parentClass.box.InterpreterExit();
+
+				return ret;
+			}
+			finally
+			{
+				if( usingSingleParameterCache )
+				{
+					parameters[0] = default;
+					singleParameterCacheInUse = false;
+				}
+				stackPool.Return(stackBuffer, clearArray: true);
+			}
 		}
 
 		private StackElement InterpretInner( ArraySegment<StackElement> stackBufferIn, ArraySegment<StackElement> parametersIn )
@@ -445,14 +477,18 @@ spiperf.Begin();
 							object callthis = null;
 							Type[] paTypes = dt.nativeParameterTypes;
 							int numFields = paTypes.Length;
-							object [] callpar = new object[numFields];
-							StackElement [] callpar_se = new StackElement[numFields];
+							object [] callpar = numFields == 0 ? Array.Empty<object>() : new object[numFields];
+							StackElement [] callpar_se = null;
 
 							int ik;
 							for( ik = 0; ik < numFields; ik++ )
 							{
 								StackElement se = stackBuffer[sp--];
-								callpar_se[numFields-ik-1] = se;
+								if( se.type == StackType.Address || se.type == StackType.NativeHandle )
+								{
+									callpar_se ??= new StackElement[numFields];
+									callpar_se[numFields-ik-1] = se;
+								}
 								object o = se.AsObject(box);
 								Type t = paTypes[numFields-ik-1];
 
@@ -600,16 +636,15 @@ spiperf.Begin();
 							}
 
 							// Possibly copy back any references.
-							for( ik = 0; ik < numFields; ik++ )
+							if( callpar_se != null )
 							{
-								StackElement se = callpar_se[ik];
-								if (se.type == StackType.Address)
+								for( ik = 0; ik < numFields; ik++ )
 								{
-									callpar_se[ik].DereferenceLoadAddress( callpar[ik] );
-								}
-								else if ( se.type == StackType.NativeHandle )
-								{
-									callpar_se[ik].DereferenceLoadNativeHandle( box, callpar[ik] );
+									StackElement se = callpar_se[ik];
+									if (se.type == StackType.Address)
+										callpar_se[ik].DereferenceLoadAddress( callpar[ik] );
+									else if (se.type == StackType.NativeHandle)
+										callpar_se[ik].DereferenceLoadNativeHandle( box, callpar[ik] );
 								}
 							}
 


### PR DESCRIPTION
## Changes
* Reuse interpreter stack buffers through a private ArrayPool<StackElement>.
* Clear pooled stack buffers when returned so managed references are released safely.
* Avoid parameter-array allocations for zero-argument calls with Array.Empty<StackElement>().
* Reuse a thread-static single-parameter buffer for the common one-argument case.
* Preserve safe behavior for recursive/reentrant execution by falling back to a normal allocation when the cached parameter buffer is already in use.
* Use Array.Empty<object>() for zero-argument native calls.
* Lazily allocate the native-call StackElement[] copyback buffer only when an argument is actually an Address or NativeHandle.
* Skip the copyback loop entirely for normal native calls that cannot modify interpreter values by reference.

## Performance Chart for --perf
* Overall about 3% faster with lot lower GC

| Metric | Current master | Optimized |
|---|---:|---:|
| Perf root total | 1,416,512 µs | 1,373,649 µs |
| Peer total | 359,519 µs | 348,843 µs |
| Recursive | 11,297 µs | 11,231 µs |
| Fourier | 78,745 µs | 73,739 µs |
| Trig | 891,213 µs | 864,219 µs |
| Matrix | 74,908 µs | 74,794 µs |
| Peer calls | 359,582 µs | 348,897 µs |
